### PR TITLE
Process footnotes.xml

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 **dev**
 
 - Allow a file-like object to be passed into the DocXParser constructor.
+- Added basic support for footnotes.
 
 **0.4.2**
 

--- a/pydocx/DocxParser.py
+++ b/pydocx/DocxParser.py
@@ -180,6 +180,7 @@ class DocxParser(MulitMemoizeMixin):
             'delText': self.parse_deletion,
             'drawing': self.parse_image,
             'footnoteReference': self.parse_footnote_reference,
+            'footnoteRef': self.parse_footnote_ref,
             'hyperlink': self.parse_hyperlink,
             'ins': self.parse_insertion,
             'noBreakHyphen': self.parse_hyphen,
@@ -271,6 +272,14 @@ class DocxParser(MulitMemoizeMixin):
             # pgSz is defined in twips, convert to points
             pgSz = int(pgSzEl.attrib['w'])
             return pgSz / TWIPS_PER_POINT
+
+    def parse_footnote_ref(self, el, text, stack):
+        footnote_id = None
+        for item in reversed(stack):
+            if item['element'].tag == 'footnote':
+                footnote_id = item['element'].get('id')
+                break
+        return self.footnote_ref(footnote_id)
 
     def parse_footnote_reference(self, el, text, stack):
         footnote_id = el.get('id')

--- a/pydocx/__init__.py
+++ b/pydocx/__init__.py
@@ -34,7 +34,7 @@ def main():
     else:
         print('Only valid parsers are --html and --markdown')
         sys.exit()
-    with open(path_to_html, 'w') as f:
+    with open(path_to_html, 'wb') as f:
         f.write(html.encode('utf-8'))
 
 if __name__ == '__main__':

--- a/pydocx/openxml.py
+++ b/pydocx/openxml.py
@@ -19,7 +19,7 @@ class OpenXmlPartContainer(object):
     See also: http://msdn.microsoft.com/en-us/library/documentformat.openxml.packaging.openxmlpartcontainer%28v=office.14%29.aspx  # noqa
     '''
 
-    child_part_types = NotImplemented
+    child_part_types = []
 
     def __init__(self):
         self.external_relationships = {}

--- a/pydocx/packaging.py
+++ b/pydocx/packaging.py
@@ -156,7 +156,7 @@ class ZipPackagePart(PackageRelationshipManager):
     @staticmethod
     def get_relationship_part_uri(part_uri):
         container, filename = posixpath.split(part_uri)
-        filename_rels = '%s.rels' % filename
+        filename_rels = '{file}.rels'.format(file=filename)
         return posixpath.join(container, '_rels', filename_rels)
 
     def get_part_container(self):
@@ -219,8 +219,8 @@ class ZipPackage(PackageRelationshipManager):
         self._ensure_parts_are_loaded()
         if self.part_exists(uri):
             raise RuntimeError(
-                'A part with the specified URI "%s" already exists' % (
-                    uri,
+                'A part with the specified URI "{uri}" already exists'.format(
+                    uri=uri,
                 )
             )
         part = ZipPackagePart(package=self, uri=uri)

--- a/pydocx/parsers/Docx2Html.py
+++ b/pydocx/parsers/Docx2Html.py
@@ -59,7 +59,8 @@ class Docx2Html(DocxParser):
             for footnote_id in self.footnote_ordering
         ]
         if footnotes:
-            return '<hr/>{footnotes}'.format(
+            return '{page_break}{footnotes}'.format(
+                page_break=self.page_break(),
                 footnotes=self.ordered_list(
                     text=''.join(footnotes),
                     list_style='decimal',

--- a/pydocx/parsers/Docx2Html.py
+++ b/pydocx/parsers/Docx2Html.py
@@ -55,10 +55,7 @@ class Docx2Html(DocxParser):
 
     def footnotes(self):
         footnotes = [
-            self.footnote(
-                footnote_id,
-                self.footnote_id_to_content[footnote_id],
-            )
+            self.footnote(self.footnote_id_to_content[footnote_id])
             for footnote_id in self.footnote_ordering
         ]
         if footnotes:
@@ -68,10 +65,20 @@ class Docx2Html(DocxParser):
         else:
             return ''
 
-    def footnote(self, footnote_id, content):
-        return '<li><a name="footnote-{id}"></a>{content}</li>'.format(
-            id=footnote_id,
-            content=content,
+    def footnote_ref(self, footnote_id):
+        return self.make_element(
+            tag='a',
+            attrs=dict(
+                href='#footnote-ref-{id}',
+                name='footnote-{id}'
+            ),
+            contents='^',
+        ).format(id=footnote_id)
+
+    def footnote(self, content):
+        return self.make_element(
+            tag='li',
+            contents=content,
         )
 
     def style(self):
@@ -104,7 +111,15 @@ class Docx2Html(DocxParser):
         )
 
     def footnote_reference(self, footnote_id, index):
-        return '<a href="#footnote-{id}">{index}</a>'.format(
+        anchor = self.make_element(
+            tag='a',
+            attrs=dict(
+                href='#footnote-{id}',
+                name='footnote-ref-{id}'
+            ),
+            contents='{index}',
+        )
+        return anchor.format(
             id=footnote_id,
             index=index,
         )

--- a/pydocx/parsers/Docx2Html.py
+++ b/pydocx/parsers/Docx2Html.py
@@ -25,10 +25,10 @@ class Docx2Html(DocxParser):
     @property
     def parsed(self):
         content = super(Docx2Html, self).parsed
-        content = "<html>%(head)s<body>%(content)s</body></html>" % {
-            'head': self.head(),
-            'content': content,
-        }
+        content = '<html>{header}<body>{body}</body></html>'.format(
+            header=self.head(),
+            body=content,
+        )
         return content
 
     def make_element(self, tag, contents='', attrs=None):

--- a/pydocx/parsers/Docx2Html.py
+++ b/pydocx/parsers/Docx2Html.py
@@ -35,14 +35,14 @@ class Docx2Html(DocxParser):
     def make_element(self, tag, contents='', attrs=None):
         if attrs:
             attrs = convert_dictionary_to_html_attributes(attrs)
-            template = '<%(tag)s %(attrs)s>%(contents)s</%(tag)s>'
+            template = '<{tag} {attrs}>{contents}</{tag}>'
         else:
-            template = '<%(tag)s>%(contents)s</%(tag)s>'
-        return template % {
-            'tag': tag,
-            'attrs': attrs,
-            'contents': contents,
-        }
+            template = '<{tag}>{contents}</{tag}>'
+        return template.format(
+            tag=tag,
+            attrs=attrs,
+            contents=contents,
+        )
 
     def head(self):
         return self.make_element(

--- a/pydocx/parsers/Docx2Html.py
+++ b/pydocx/parsers/Docx2Html.py
@@ -25,9 +25,10 @@ class Docx2Html(DocxParser):
     @property
     def parsed(self):
         content = super(Docx2Html, self).parsed
-        content = '<html>{header}<body>{body}</body></html>'.format(
+        content = '<html>{header}<body>{body}{footer}</body></html>'.format(
             header=self.head(),
             body=content,
+            footer=self.footer(),
         )
         return content
 
@@ -47,6 +48,30 @@ class Docx2Html(DocxParser):
         return self.make_element(
             tag='head',
             contents=self.style(),
+        )
+
+    def footer(self):
+        return self.footnotes()
+
+    def footnotes(self):
+        footnotes = [
+            self.footnote(
+                footnote_id,
+                self.footnote_id_to_content[footnote_id],
+            )
+            for footnote_id in self.footnote_ordering
+        ]
+        if footnotes:
+            return '<hr/><ol>{footnotes}</ol>'.format(
+                footnotes=''.join(footnotes),
+            )
+        else:
+            return ''
+
+    def footnote(self, footnote_id, content):
+        return '<li><a name="footnote-{id}"></a>{content}</li>'.format(
+            id=footnote_id,
+            content=content,
         )
 
     def style(self):
@@ -76,6 +101,12 @@ class Docx2Html(DocxParser):
         return self.make_element(
             tag='style',
             contents=''.join(result),
+        )
+
+    def footnote_reference(self, footnote_id, index):
+        return '<a href="#footnote-{id}">{index}</a>'.format(
+            id=footnote_id,
+            index=index,
         )
 
     def escape(self, text):

--- a/pydocx/parsers/Docx2Html.py
+++ b/pydocx/parsers/Docx2Html.py
@@ -59,8 +59,11 @@ class Docx2Html(DocxParser):
             for footnote_id in self.footnote_ordering
         ]
         if footnotes:
-            return '<hr/><ol type="1">{footnotes}</ol>'.format(
-                footnotes=''.join(footnotes),
+            return '<hr/>{footnotes}'.format(
+                footnotes=self.ordered_list(
+                    text=''.join(footnotes),
+                    list_style='decimal',
+                )
             )
         else:
             return ''

--- a/pydocx/parsers/Docx2Html.py
+++ b/pydocx/parsers/Docx2Html.py
@@ -59,7 +59,7 @@ class Docx2Html(DocxParser):
             for footnote_id in self.footnote_ordering
         ]
         if footnotes:
-            return '<hr/><ol>{footnotes}</ol>'.format(
+            return '<hr/><ol type="1">{footnotes}</ol>'.format(
                 footnotes=''.join(footnotes),
             )
         else:

--- a/pydocx/tests/__init__.py
+++ b/pydocx/tests/__init__.py
@@ -21,7 +21,7 @@ from pydocx.packaging import PackageRelationship
 from pydocx.parsers.Docx2Html import Docx2Html
 from pydocx.tests.document_builder import DocxBuilder as DXB
 from pydocx.util.xml import parse_xml_from_string
-from pydocx.util.zip import ZipFile
+from pydocx.util.zip import create_zip_archive
 from pydocx.wordml import (
     MainDocumentPart,
     NumberingDefinitionsPart,
@@ -225,14 +225,7 @@ class DocumentGeneratorTestCase(TestCase):
             '[Content_Types].xml': self.content_types,
         }
 
-        buf = BytesIO()
-        with ZipFile(buf, 'w') as zf:
-            for arcname, data in document.items():
-                if data is None:
-                    continue
-                zf.writestr(arcname, data.encode('utf-8'))
-
-        yield buf
+        yield create_zip_archive(document)
 
     def assert_xml_body_matches_expected_html(self, expected, **kwargs):
         '''

--- a/pydocx/tests/__init__.py
+++ b/pydocx/tests/__init__.py
@@ -391,7 +391,7 @@ class XMLDocx2Html(Docx2Html):
         )
         self.styles = self.styles_manager.styles
 
-        self.parse_begin(self.document.main_document_part.root_element)
+        self.parse_begin(self.document.main_document_part)
 
     def get_list_style(self, num_id, ilvl):
         try:

--- a/pydocx/tests/__init__.py
+++ b/pydocx/tests/__init__.py
@@ -6,6 +6,7 @@ from __future__ import (
 
 import posixpath
 import re
+import os.path
 from contextlib import contextmanager
 from xml.dom import minidom
 from unittest import TestCase
@@ -17,7 +18,7 @@ except ImportError:
     from io import BytesIO
 
 from pydocx.managers.styles import StylesManager
-from pydocx.packaging import PackageRelationship
+from pydocx.packaging import PackageRelationship, ZipPackagePart
 from pydocx.parsers.Docx2Html import Docx2Html
 from pydocx.tests.document_builder import DocxBuilder as DXB
 from pydocx.util.xml import parse_xml_from_string
@@ -129,118 +130,185 @@ class Docx2HtmlNoStyle(Docx2Html):
         return ''
 
 
-class DocumentGeneratorTestCase(TestCase):
-    '''
-    A test case class that can be inherited to compare xml fragments with their
-    resulting HTML output.  This is achieved by generating a document container
-    on the fly in a temporary location and then using the parser to convert
-    that document.
-    Each test case needs to call `assert_xml_body_matches_expected_html`
-    '''
+class WordprocessingDocumentFactory(object):
+    PARTS_TO_PATHS = {
+        MainDocumentPart: 'word/document.xml',
+        StyleDefinitionsPart: 'word/styles.xml',
+        NumberingDefinitionsPart: 'word/numbering.xml',
+    }
 
-    base_relationships = '''
-        <Relationships xmlns="{PackageRelationshipNamespace}">
-          <Relationship Id="rId1" Type="{MainDocumentPartNamespace}"
-            Target="word/document.xml"/>
-        </Relationships>
-    '''.format(
-        PackageRelationshipNamespace=PackageRelationship.namespace,
-        MainDocumentPartNamespace=MainDocumentPart.relationship_type,
-    )
+    PARTS_TO_PREPARE_CONTENT_FUNCS = {
+        MainDocumentPart: 'prepare_main_document_content',
+        StyleDefinitionsPart: 'prepare_style_content',
+    }
+
+    xml_header = '<?xml version="1.0" encoding="UTF-8"?>'
+
+    relationship_format = '''
+        <Relationship Id="{id}" Type="{type}" Target="{target}" TargetMode="{target_mode}"/>
+    '''  # noqa
 
     content_types = '''
         <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
           <Override PartName="/_rels/.rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
           <Override PartName="/word/_rels/document.xml.rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
-          <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
           <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
         </Types>
     '''  # noqa
 
-    def wrap_xml(self, xml):
-        return '<?xml version="1.0" encoding="UTF-8"?>%s' % xml
+    def __init__(self, items=None):
+        self.items = items
+        if not self.items:
+            self.items = {}
 
-    def wrap_body_xml(self, xml):
-        xml = '<document><body>%s</body></document>' % xml
-        return self.wrap_xml(xml)
-
-    def wrap_style_xml(self, xml):
-        xml = '<styles>%s</styles>' % xml
-        return self.wrap_xml(xml)
-
-    def wrap_numbering_xml(self, xml):
-        xml = '<numbering>%s</numbering>' % xml,
-        return self.wrap_xml(xml)
-
-    def wrap_relationship_xml(self, xml):
-        xml = '''
-            <Relationships xmlns="{namespace}">
-            {xml}
-            </Relationships>
-        '''.format(
-            namespace=PackageRelationship.namespace,
-            xml=xml,
-        )
-        return self.wrap_xml(xml)
-
-    @contextmanager
-    def build_and_convert_document_to_html(
-        self,
-        body=None,
-        style=None,
-        numbering=None,
-        word_relationships=None,
-    ):
-        default_word_relationships = '''
-          <Relationship Id="rId1" Type="{styles_rel_type}"
-            Target="styles.xml"/>
-          <Relationship Id="rId2" Type="{numbering_rel_type}"
-            Target="numbering.xml"/>
-        '''.format(
-            styles_rel_type=StyleDefinitionsPart.relationship_type,
-            numbering_rel_type=NumberingDefinitionsPart.relationship_type,
-        )
-
-        if word_relationships is None:
-            word_relationships = default_word_relationships
-
-        if word_relationships:
-            word_relationships = self.wrap_relationship_xml(word_relationships)
-
-        if body:
-            body = self.wrap_body_xml(body)
-
-        if style:
-            style = self.wrap_style_xml(style)
-
-        if numbering:
-            numbering = self.wrap_numbering_xml(numbering)
-
-        document = {
-            '_rels/.rels': self.base_relationships,
-            'word/_rels/document.xml.rels': word_relationships,
-            'word/document.xml': body,
-            'word/styles.xml': style,
-            'word/numbering.xml': numbering,
-            '[Content_Types].xml': self.content_types,
-        }
-
-        yield create_zip_archive(document)
-
-    def assert_xml_body_matches_expected_html(self, expected, **kwargs):
+    def to_zip_dict(self):
         '''
-        Given an XML body, generate a document container, then convert that
-        container to HTML and compare it with the given result.
+        Return a dictionary that can be passed to ``create_zip_archive``
+        The keys specify paths within the zip archive, and the values specify
+        the data at that path.
         '''
-        manager = self.build_and_convert_document_to_html(**kwargs)
-        with manager as docx_path:
-            parser = Docx2HtmlNoStyle(docx_path)
-            actual = parser.parsed
-            expected = BASE_HTML_NO_STYLE % expected
-            if not html_is_equal(actual, expected):
-                actual = prettify(actual)
-                message = 'The expected HTML did not match the actual HTML:'
-                raise AssertionError(message + '\n' + actual)
+
+        zip_dict = {}
+        part_class_to_uri = {}
+
+        for item_class, (content, rels) in self.items.items():
+            uri = self.PARTS_TO_PATHS[item_class]
+            part_class_to_uri[item_class] = uri
+            zip_dict[uri] = content
+            if rels:
+                rels_uri = ZipPackagePart.get_relationship_part_uri(uri)
+                zip_dict[rels_uri] = rels
+
+        base_uri, base_content = self.get_base_relationships(part_class_to_uri)
+        zip_dict[base_uri] = base_content
+
+        content_types_uri, content_types = self.get_content_types()
+        zip_dict[content_types_uri] = content_types
+
+        return zip_dict
+
+    def add(self, item_part_class, content, relationships=None):
+        '''
+        Add an item of type `item_part_class` to the document with content
+        `content`. Optionally, you can specify the `relationships` this item
+        has.
+
+        For example:
+
+            document = WordprocessingDocumentFactory()
+            document.add(MainDocumentPart, '<p>Foo</p>')
+
+        Internal relationships are managed automatically by adding the items
+        which are children before adding the parent:
+
+            document = WordprocessingDocumentFactory()
+            document.add(StyleDefinitionsPart, '<style>...</style>')
+            document.add(MainDocumentPart, '<p>Foo</p>')
+
+        In the above example, the MainDocumentPart item will automatically
+        acquire the StyleDefinitionsPart as a child item.
+
+        For external relationships, you can pass them in directly:
+
+            document = WordprocessingDocumentFactory()
+            document_rels = document.relationship_format.format(
+                id='foobar',
+                type=ImagePart.relationship_type,
+                target='http://google.com/logo.gif',
+                target_mode='External',
+            )
+            document.add(MainDocumentPart, '<p>Foo</p>', document_rels)
+
+        The external relationships will be combined with any automatic
+        relationships that existed.
+        '''
+        func_name = self.PARTS_TO_PREPARE_CONTENT_FUNCS.get(item_part_class)
+        func = getattr(self, func_name)
+        if callable(func):
+            content = func(content)
+        relationships = self.prepare_relationship_data(
+            content=relationships,
+            item_part_class=item_part_class,
+        )
+        self.items[item_part_class] = (content, relationships)
+
+    def prepare_xml_content(self, xml):
+        return '{header}{xml}'.format(header=self.xml_header, xml=xml)
+
+    def prepare_relationship_data(self, content, item_part_class=None):
+        if item_part_class:
+            # Automatically build relationships based on the defined child
+            # types and previously added parts to this factory
+            relevant_part_classes = (
+                set(item_part_class.child_part_types) & set(self.items.keys())
+            )
+            automatic_rels = ''.join(self.build_relationship_content(dict(
+                (
+                    part_class,
+                    self.get_part_name(item_part_class, part_class),
+                )
+                for part_class in relevant_part_classes
+            )))
+            if content:
+                content = content + automatic_rels
+            else:
+                content = automatic_rels
+        xml = '<Relationships xmlns="{ns}">{rels}</Relationships>'.format(
+            ns=PackageRelationship.namespace,
+            rels=content,
+        )
+        return self.prepare_xml_content(xml=xml)
+
+    def get_part_name(self, parent_part_class, part_class):
+        parent_uri = self.PARTS_TO_PATHS[parent_part_class]
+        uri = self.PARTS_TO_PATHS[part_class]
+        return os.path.relpath(uri, os.path.dirname(parent_uri))
+
+    def get_base_relationships(self, part_class_to_uri):
+        uri = ZipPackagePart.get_relationship_part_uri('')
+        content = ''.join(self.build_relationship_content(part_class_to_uri))
+        content = self.prepare_relationship_data(content=content)
+        return uri, content
+
+    def build_relationship_content(self, part_class_to_uri):
+        for rid, (part_class, uri) in enumerate(part_class_to_uri.items()):
+            yield self.relationship_format.format(
+                id='rId{rid}'.format(rid=rid),
+                type=part_class.relationship_type,
+                target=uri,
+                target_mode='Internal',
+            )
+
+    def prepare_main_document_content(self, xml):
+        xml = '<document><body>{xml}</body></document>'.format(xml=xml)
+        return self.prepare_xml_content(xml=xml)
+
+    def prepare_style_content(self, xml):
+        xml = '<styles>{xml}</styles>'.format(xml=xml)
+        return self.prepare_xml_content(xml=xml)
+
+    def get_content_types(self):
+        content_types = self.prepare_xml_content(xml=self.content_types)
+        return '[Content_Types].xml', content_types
+
+
+class DocumentGeneratorTestCase(TestCase):
+    '''
+    A test case class that can be inherited to compare xml fragments with their
+    resulting HTML output.
+
+    Each test case needs to call `assert_document_generates_html`
+    '''
+
+    def assert_document_generates_html(self, document, expected_html):
+        zip_buf = create_zip_archive(document.to_zip_dict())
+        parser = Docx2HtmlNoStyle(zip_buf)
+        actual = parser.parsed
+        expected = BASE_HTML_NO_STYLE % expected_html
+        if not html_is_equal(actual, expected):
+            actual = prettify(actual)
+            message = 'The expected HTML did not match the actual HTML:'
+            raise AssertionError(message + '\n' + actual)
 
 
 class XMLDocx2Html(Docx2Html):

--- a/pydocx/tests/__init__.py
+++ b/pydocx/tests/__init__.py
@@ -24,6 +24,7 @@ from pydocx.tests.document_builder import DocxBuilder as DXB
 from pydocx.util.xml import parse_xml_from_string
 from pydocx.util.zip import create_zip_archive
 from pydocx.wordml import (
+    FootnotesPart,
     MainDocumentPart,
     NumberingDefinitionsPart,
     StyleDefinitionsPart,
@@ -132,12 +133,14 @@ class Docx2HtmlNoStyle(Docx2Html):
 
 class WordprocessingDocumentFactory(object):
     PARTS_TO_PATHS = {
+        FootnotesPart: 'word/footnotes.xml',
         MainDocumentPart: 'word/document.xml',
         StyleDefinitionsPart: 'word/styles.xml',
         NumberingDefinitionsPart: 'word/numbering.xml',
     }
 
     PARTS_TO_PREPARE_CONTENT_FUNCS = {
+        FootnotesPart: 'prepare_footnotes_content',
         MainDocumentPart: 'prepare_main_document_content',
         StyleDefinitionsPart: 'prepare_style_content',
     }
@@ -285,6 +288,10 @@ class WordprocessingDocumentFactory(object):
 
     def prepare_style_content(self, xml):
         xml = '<styles>{xml}</styles>'.format(xml=xml)
+        return self.prepare_xml_content(xml=xml)
+
+    def prepare_footnotes_content(self, xml):
+        xml = '<footnotes>{xml}</footnotes>'.format(xml=xml)
         return self.prepare_xml_content(xml=xml)
 
     def get_content_types(self):

--- a/pydocx/tests/test_html.py
+++ b/pydocx/tests/test_html.py
@@ -9,10 +9,70 @@ from pydocx.tests import (
     WordprocessingDocumentFactory,
 )
 from pydocx.wordml import (
+    FootnotesPart,
     ImagePart,
     MainDocumentPart,
     StyleDefinitionsPart,
 )
+
+
+class FootnoteTestCase(DocumentGeneratorTestCase):
+    def test_footnote_without_definition_is_ignored(self):
+        document_xml = '''
+            <p>
+              <r>
+                <t>Foo</t>
+              </r>
+              <r>
+                <footnoteReference id="abc"/>
+              </r>
+            </p>
+        '''
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '<p>Foo</p>'
+        self.assert_document_generates_html(document, expected_html)
+
+    def test_basic_footnote(self):
+        document_xml = '''
+            <p>
+              <r>
+                <t>Foo</t>
+              </r>
+              <r>
+                <rPr>
+                  <vertAlign val="superscript"/>
+                </rPr>
+                <footnoteReference id="abc"/>
+              </r>
+            </p>
+        '''
+
+        footnotes_xml = '''
+            <footnote id="abc">
+              <p>
+                <r>
+                  <t>Bar</t>
+                </r>
+              </p>
+            </footnote>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(FootnotesPart, footnotes_xml)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <p>Foo<sup><a href="#footnote-1">1</a></sup></p>
+            <ol>
+                <li><a name="footnote-1">Bar</a></li>
+            </ol>
+        '''
+        self.assert_document_generates_html(document, expected_html)
+
+    def test_footnote_with_hyperlink(self):
+        pass
 
 
 class ParagraphTestCase(DocumentGeneratorTestCase):

--- a/pydocx/tests/test_html.py
+++ b/pydocx/tests/test_html.py
@@ -142,6 +142,91 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
         '''
         self.assert_document_generates_html(document, expected_html)
 
+    def test_multiple_footnotes_defined_in_a_order_different_from_usage(self):
+        document_xml = '''
+            <p>
+              <r>
+                <t>Foo</t>
+              </r>
+              <r>
+                <rPr>
+                  <vertAlign val="superscript"/>
+                </rPr>
+                <footnoteReference id="one"/>
+              </r>
+              <r>
+                <t>Bar</t>
+              </r>
+              <r>
+                <rPr>
+                  <vertAlign val="superscript"/>
+                </rPr>
+                <footnoteReference id="two"/>
+              </r>
+              <r>
+                <t>Baz</t>
+              </r>
+              <r>
+                <rPr>
+                  <vertAlign val="superscript"/>
+                </rPr>
+                <footnoteReference id="three"/>
+              </r>
+            </p>
+            <p>
+              <r>
+                <t>Footnotes should appear below this</t>
+              </r>
+            </p>
+        '''
+
+        footnotes_xml = '''
+            <footnote id="two">
+              <p>
+                <r>
+                  <footnoteRef/>
+                  <t>Beta</t>
+                </r>
+              </p>
+            </footnote>
+            <footnote id="three">
+              <p>
+                <r>
+                  <footnoteRef/>
+                  <t>Gamma</t>
+                </r>
+              </p>
+            </footnote>
+            <footnote id="one">
+              <p>
+                <r>
+                  <footnoteRef/>
+                  <t>Alpha</t>
+                </r>
+              </p>
+            </footnote>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(FootnotesPart, footnotes_xml)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <p>
+                Foo<sup><a href="#footnote-one">1</a></sup>
+                Bar<sup><a href="#footnote-two">2</a></sup>
+                Baz<sup><a href="#footnote-three">3</a></sup>
+            </p>
+            <p>Footnotes should appear below this</p>
+            <hr/>
+            <ol>
+                <li><a name="footnote-one"></a><p>Alpha</p></li>
+                <li><a name="footnote-two"></a><p>Beta</p></li>
+                <li><a name="footnote-three"></a><p>Gamma</p></li>
+            </ol>
+        '''
+        self.assert_document_generates_html(document, expected_html)
+
 
 class ParagraphTestCase(DocumentGeneratorTestCase):
     def test_multiple_text_tags_in_a_single_run_tag_create_single_paragraph(

--- a/pydocx/tests/test_html.py
+++ b/pydocx/tests/test_html.py
@@ -80,7 +80,7 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
                 </sup>
             </p>
             <p>Footnotes should appear below this</p>
-            <hr/>
+            <hr />
             <ol list-style-type="decimal">
                 <li><p><strong>
                     <a href="#footnote-ref-abc" name="footnote-abc">^</a>
@@ -145,7 +145,7 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
                 </sup>
             </p>
             <p>Footnotes should appear below this</p>
-            <hr/>
+            <hr />
             <ol list-style-type="decimal">
                 <li>
                     <p>
@@ -242,7 +242,7 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
                 </sup>
             </p>
             <p>Footnotes should appear below this</p>
-            <hr/>
+            <hr />
             <ol list-style-type="decimal">
                 <li><p>
                     <a href="#footnote-ref-one" name="footnote-one">^</a>

--- a/pydocx/tests/test_html.py
+++ b/pydocx/tests/test_html.py
@@ -4,15 +4,22 @@ from __future__ import (
     unicode_literals,
 )
 
-from pydocx.tests import DocumentGeneratorTestCase
-from pydocx.wordml import ImagePart
+from pydocx.tests import (
+    DocumentGeneratorTestCase,
+    WordprocessingDocumentFactory,
+)
+from pydocx.wordml import (
+    ImagePart,
+    MainDocumentPart,
+    StyleDefinitionsPart,
+)
 
 
 class ParagraphTestCase(DocumentGeneratorTestCase):
     def test_multiple_text_tags_in_a_single_run_tag_create_single_paragraph(
         self,
     ):
-        xml_body = '''
+        document_xml = '''
             <p>
               <r>
                 <t>A</t>
@@ -21,46 +28,46 @@ class ParagraphTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p>ABC</p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_empty_text_tag_does_not_create_paragraph(self):
-        xml_body = '''
+        document_xml = '''
             <p>
               <r>
                 <t></t>
               </r>
             </p>
         '''
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = ''
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_unicode_character(self):
-        xml_body = '''
+        document_xml = '''
             <p>
               <r>
                 <t>&#x10001F;</t>
               </r>
             </p>
         '''
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p>\U0010001f</p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
 
 class HeadingTestCase(DocumentGeneratorTestCase):
     def test_character_stylings_are_ignored(self):
         # Even though the heading1 style has bold enabled, it's being ignored
         # because the style is for a header
-        style = '''
+        style_xml = '''
             <style styleId="heading1" type="paragraph">
               <name val="Heading 1"/>
               <rPr>
@@ -69,7 +76,7 @@ class HeadingTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        xml_body = '''
+        document_xml = '''
             <p>
               <pPr>
                 <pStyle val="heading1"/>
@@ -79,14 +86,15 @@ class HeadingTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '''
             <h1>aaa</h1>
         '''
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            style=style,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_each_heading_level(self):
         style_template = '''
@@ -95,7 +103,7 @@ class HeadingTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        style = ''.join(
+        style_xml = ''.join(
             style_template % (i, i)
             for i in range(1, 11)
         )
@@ -124,10 +132,14 @@ class HeadingTestCase(DocumentGeneratorTestCase):
             ('heading10', 'jjj'),
         ]
 
-        xml_body = ''.join(
+        document_xml = ''.join(
             paragraph_template % entry
             for entry in style_to_text
         )
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
 
         expected_html = '''
             <h1>aaa</h1>
@@ -141,16 +153,12 @@ class HeadingTestCase(DocumentGeneratorTestCase):
             <h6>iii</h6>
             <h6>jjj</h6>
         '''
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            style=style,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
 
 class PageBreakTestCase(DocumentGeneratorTestCase):
     def test_before_text_run(self):
-        xml_body = '''
+        document_xml = '''
             <p>
               <r>
                 <t>aaa</t>
@@ -163,14 +171,15 @@ class PageBreakTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p>aaa</p><p><hr />bbb</p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_between_paragraphs(self):
-        xml_body = '''
+        document_xml = '''
             <p>
               <r>
                 <t>aaa</t>
@@ -187,14 +196,15 @@ class PageBreakTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p>aaa</p><p><hr /></p><p>bbb</p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_after_text_run(self):
-        xml_body = '''
+        document_xml = '''
             <p>
               <r>
                 <t>aaa</t>
@@ -207,16 +217,17 @@ class PageBreakTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p>aaa<hr /></p><p>bbb</p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
 
 class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
     def test_local_character_style(self):
-        xml_body = '''
+        document_xml = '''
             <p>
               <r>
                 <rPr>
@@ -226,14 +237,15 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p><strong>aaa</strong></p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_global_run_character_style(self):
-        style = '''
+        style_xml = '''
             <style styleId="foo" type="character">
               <rPr>
                 <b val="on"/>
@@ -241,7 +253,7 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        xml_body = '''
+        document_xml = '''
             <p>
               <r>
                 <rPr>
@@ -251,15 +263,16 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p><strong>aaa</strong></p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            style=style,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_global_run_paragraph_style(self):
-        style = '''
+        style_xml = '''
             <style styleId="foo" type="paragraph">
               <rPr>
                 <b val="on"/>
@@ -267,7 +280,7 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        xml_body = '''
+        document_xml = '''
             <p>
               <pPr>
                 <pStyle val="foo"/>
@@ -277,15 +290,16 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p><strong>aaa</strong></p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            style=style,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_global_run_paragraph_and_character_styles(self):
-        style = '''
+        style_xml = '''
             <style styleId="foo" type="paragraph">
               <rPr>
                 <b val="on"/>
@@ -298,7 +312,7 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        xml_body = '''
+        document_xml = '''
             <p>
               <pPr>
                 <pStyle val="foo"/>
@@ -311,15 +325,16 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p><em><strong>aaa</strong></em></p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            style=style,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_local_styles_override_global_styles(self):
-        style = '''
+        style_xml = '''
             <style styleId="foo" type="paragraph">
               <rPr>
                 <b val="on"/>
@@ -332,7 +347,7 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        xml_body = '''
+        document_xml = '''
             <p>
               <pPr>
                 <pStyle val="foo"/>
@@ -347,15 +362,16 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p>aaa</p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            style=style,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_paragraph_style_referenced_by_run_is_ignored(self):
-        style = '''
+        style_xml = '''
             <style styleId="foo" type="paragraph">
               <rPr>
                 <b val="on"/>
@@ -363,7 +379,7 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        xml_body = '''
+        document_xml = '''
             <p>
               <r>
                 <rPr>
@@ -373,15 +389,16 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p>aaa</p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            style=style,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_character_style_referenced_by_paragraph_is_ignored(self):
-        style = '''
+        style_xml = '''
             <style styleId="foo" type="character">
               <rPr>
                 <b val="on"/>
@@ -389,7 +406,7 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        xml_body = '''
+        document_xml = '''
             <p>
               <pPr>
                 <pStyle val="foo"/>
@@ -399,15 +416,16 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p>aaa</p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            style=style,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_run_paragraph_mark_style_is_not_used_as_run_style(self):
-        style = '''
+        style_xml = '''
             <style styleId="foo" type="paragraph">
               <pPr>
                 <rPr>
@@ -417,7 +435,7 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        xml_body = '''
+        document_xml = '''
             <p>
               <pPr>
                 <pStyle val="foo"/>
@@ -427,17 +445,18 @@ class PropertyHierarchyTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p>aaa</p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            style=style,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
 
 class StyleBasedOnTestCase(DocumentGeneratorTestCase):
     def test_style_chain_ends_when_loop_is_detected(self):
-        style = '''
+        style_xml = '''
             <style styleId="one">
               <basedOn val="three"/>
               <rPr>
@@ -452,7 +471,7 @@ class StyleBasedOnTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        xml_body = '''
+        document_xml = '''
             <p>
               <pPr>
                 <pStyle val="three"/>
@@ -462,15 +481,16 @@ class StyleBasedOnTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p><strong>aaa</strong></p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            style=style,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_styles_are_inherited(self):
-        style = '''
+        style_xml = '''
             <style styleId="one">
               <rPr>
                 <b val="on"/>
@@ -490,7 +510,7 @@ class StyleBasedOnTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        xml_body = '''
+        document_xml = '''
             <p>
               <pPr>
                 <pStyle val="three"/>
@@ -500,6 +520,11 @@ class StyleBasedOnTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '''
             <p>
               <span class="pydocx-underline">
@@ -509,16 +534,12 @@ class StyleBasedOnTestCase(DocumentGeneratorTestCase):
               </span>
             </p>
         '''
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            style=style,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_basedon_ignored_for_character_based_on_paragraph(self):
         # character styles may only be based on other character styles
         # otherwise, the based on specification should be ignored
-        style = '''
+        style_xml = '''
             <style styleId="one" type="paragraph">
               <rPr>
                 <b val="on"/>
@@ -532,7 +553,7 @@ class StyleBasedOnTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        xml_body = '''
+        document_xml = '''
             <p>
               <r>
                 <rPr>
@@ -542,17 +563,18 @@ class StyleBasedOnTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p><em>aaa</em></p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            style=style,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_basedon_ignored_for_paragraph_based_on_character(self):
         # paragraph styles may only be based on other paragraph styles
         # otherwise, the based on specification should be ignored
-        style = '''
+        style_xml = '''
             <style styleId="one" type="character">
               <rPr>
                 <b val="on"/>
@@ -566,7 +588,7 @@ class StyleBasedOnTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        xml_body = '''
+        document_xml = '''
             <p>
               <pPr>
                 <pStyle val="two"/>
@@ -576,17 +598,18 @@ class StyleBasedOnTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p><em>aaa</em></p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            style=style,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
 
 class DirectFormattingBoldPropertyTestCase(DocumentGeneratorTestCase):
     def test_default_no_val_set(self):
-        xml_body = '''
+        document_xml = '''
             <p>
               <r>
                 <rPr>
@@ -596,11 +619,12 @@ class DirectFormattingBoldPropertyTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p><strong>foo</strong></p>'
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_valid_enable_vals_create_strong(self):
         vals = [
@@ -619,10 +643,13 @@ class DirectFormattingBoldPropertyTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
-        xml_body = ''.join(
+        document_xml = ''.join(
             paragraph_template % val
             for val in vals
         )
+
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
 
         expected_html = '''
             <p><strong>foo</strong></p>
@@ -630,10 +657,7 @@ class DirectFormattingBoldPropertyTestCase(DocumentGeneratorTestCase):
             <p><strong>foo</strong></p>
             <p><strong>foo</strong></p>
         '''
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_valid_disabled_vals_do_not_create_strong(self):
         vals = [
@@ -652,10 +676,13 @@ class DirectFormattingBoldPropertyTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
-        xml_body = ''.join(
+        document_xml = ''.join(
             paragraph_template % val
             for val in vals
         )
+
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
 
         expected_html = '''
             <p>foo</p>
@@ -663,10 +690,7 @@ class DirectFormattingBoldPropertyTestCase(DocumentGeneratorTestCase):
             <p>foo</p>
             <p>foo</p>
         '''
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_invalid_vals_do_not_create_strong(self):
         vals = [
@@ -683,26 +707,26 @@ class DirectFormattingBoldPropertyTestCase(DocumentGeneratorTestCase):
               </r>
             </p>
         '''
-        xml_body = ''.join(
+        document_xml = ''.join(
             paragraph_template % val
             for val in vals
         )
+
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
 
         expected_html = '''
             <p>foo</p>
             <p>foo</p>
         '''
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
 
 class DrawingGraphicBlipTestCase(DocumentGeneratorTestCase):
     def test_inline_image_with_multiple_ext_definitions(self):
         # Ensure that the image size can be calculated correctly even if the
         # image size ext isn't the first ext in the drawing node
-        xml_body = '''
+        document_xml = '''
             <p>
             <r>
               <t>Foo</t>
@@ -733,14 +757,16 @@ class DrawingGraphicBlipTestCase(DocumentGeneratorTestCase):
             </p>
         '''
 
+        document = WordprocessingDocumentFactory()
         image_url = 'http://google.com/image1.gif'
-        relationships = '''
-            <Relationship Id="foobar" Type="{ImagePartType}"
-                Target="{image_url}" TargetMode="External" />
-        '''.format(
-            ImagePartType=ImagePart.relationship_type,
-            image_url=image_url,
+        document_rels = document.relationship_format.format(
+            id='foobar',
+            type=ImagePart.relationship_type,
+            target=image_url,
+            target_mode='External',
         )
+
+        document.add(MainDocumentPart, document_xml, document_rels)
 
         expected_html = '''
             <p>
@@ -751,16 +777,12 @@ class DrawingGraphicBlipTestCase(DocumentGeneratorTestCase):
             </p>
         '''
 
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            word_relationships=relationships,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_anchor_with_multiple_ext_definitions(self):
         # Ensure that the image size can be calculated correctly even if the
         # image size ext isn't the first ext in the drawing node
-        xml_body = '''
+        document_xml = '''
             <p>
             <r>
               <t>Foo</t>
@@ -791,14 +813,16 @@ class DrawingGraphicBlipTestCase(DocumentGeneratorTestCase):
             </p>
         '''
 
+        document = WordprocessingDocumentFactory()
         image_url = 'http://google.com/image1.gif'
-        relationships = '''
-            <Relationship Id="foobar" Type="{ImagePartType}"
-                Target="{image_url}" TargetMode="External" />
-        '''.format(
-            ImagePartType=ImagePart.relationship_type,
-            image_url=image_url,
+        document_rels = document.relationship_format.format(
+            id='foobar',
+            type=ImagePart.relationship_type,
+            target=image_url,
+            target_mode='External',
         )
+
+        document.add(MainDocumentPart, document_xml, document_rels)
 
         expected_html = '''
             <p>
@@ -809,16 +833,12 @@ class DrawingGraphicBlipTestCase(DocumentGeneratorTestCase):
             </p>
         '''
 
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            word_relationships=relationships,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_anchor_with_no_size_ext(self):
         # Ensure the image html is still rendered even if the size cannot be
         # calculated
-        xml_body = '''
+        document_xml = '''
             <p>
             <r>
               <t>Foo</t>
@@ -843,14 +863,16 @@ class DrawingGraphicBlipTestCase(DocumentGeneratorTestCase):
             </p>
         '''
 
+        document = WordprocessingDocumentFactory()
         image_url = 'http://google.com/image1.gif'
-        relationships = '''
-            <Relationship Id="foobar" Type="{ImagePartType}"
-                Target="{image_url}" TargetMode="External" />
-        '''.format(
-            ImagePartType=ImagePart.relationship_type,
-            image_url=image_url,
+        document_rels = document.relationship_format.format(
+            id='foobar',
+            type=ImagePart.relationship_type,
+            target=image_url,
+            target_mode='External',
         )
+
+        document.add(MainDocumentPart, document_xml, document_rels)
 
         expected_html = '''
             <p>
@@ -860,16 +882,12 @@ class DrawingGraphicBlipTestCase(DocumentGeneratorTestCase):
             </p>
         '''
 
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            word_relationships=relationships,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
     def test_blip_embed_refers_to_undefined_image_relationship(self):
         # Ensure that if a blip embed refers to an undefined image
         # relationshipp, the image rendering is skipped
-        xml_body = '''
+        document_xml = '''
             <p>
             <r>
               <t>Foo</t>
@@ -891,17 +909,17 @@ class DrawingGraphicBlipTestCase(DocumentGeneratorTestCase):
             </p>
         '''
 
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
         expected_html = '<p>FooBar</p>'
 
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-        )
+        self.assert_document_generates_html(document, expected_html)
 
 
 class HyperlinkTestCase(DocumentGeneratorTestCase):
     def test_single_run(self):
-        xml_body = '''
+        document_xml = '''
             <p>
               <hyperlink id="foobar">
                 <r>
@@ -914,21 +932,21 @@ class HyperlinkTestCase(DocumentGeneratorTestCase):
             </p>
         '''
 
-        expected_html = '<p><a href="http://google.com">link</a>.</p>'
-
-        relationships = '''
-            <Relationship Id="foobar" Type="foo/hyperlink"
-                Target="http://google.com" TargetMode="External" />
-        '''
-
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            word_relationships=relationships,
+        document = WordprocessingDocumentFactory()
+        document_rels = document.relationship_format.format(
+            id='foobar',
+            type='foo/hyperlink',
+            target='http://google.com',
+            target_mode='External',
         )
 
+        document.add(MainDocumentPart, document_xml, document_rels)
+
+        expected_html = '<p><a href="http://google.com">link</a>.</p>'
+        self.assert_document_generates_html(document, expected_html)
+
     def test_multiple_runs(self):
-        xml_body = '''
+        document_xml = '''
             <p>
               <hyperlink id="foobar">
                 <r>
@@ -944,41 +962,41 @@ class HyperlinkTestCase(DocumentGeneratorTestCase):
             </p>
         '''
 
-        expected_html = '<p><a href="http://google.com">link</a>.</p>'
-
-        relationships = '''
-            <Relationship Id="foobar" Type="foo/hyperlink"
-                Target="http://google.com" TargetMode="External" />
-        '''
-
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            word_relationships=relationships,
+        document = WordprocessingDocumentFactory()
+        document_rels = document.relationship_format.format(
+            id='foobar',
+            type='foo/hyperlink',
+            target='http://google.com',
+            target_mode='External',
         )
 
+        document.add(MainDocumentPart, document_xml, document_rels)
+
+        expected_html = '<p><a href="http://google.com">link</a>.</p>'
+        self.assert_document_generates_html(document, expected_html)
+
     def test_no_link_text(self):
-        xml_body = '''
+        document_xml = '''
             <p>
               <hyperlink id="foobar" />
             </p>
         '''
 
-        expected_html = ''
-
-        relationships = '''
-            <Relationship Id="foobar" Type="foo/hyperlink"
-                Target="http://google.com" TargetMode="External" />
-        '''
-
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            word_relationships=relationships,
+        document = WordprocessingDocumentFactory()
+        document_rels = document.relationship_format.format(
+            id='foobar',
+            type='foo/hyperlink',
+            target='http://google.com',
+            target_mode='External',
         )
 
+        document.add(MainDocumentPart, document_xml, document_rels)
+
+        expected_html = ''
+        self.assert_document_generates_html(document, expected_html)
+
     def test_undefined_relationship(self):
-        xml_body = '''
+        document_xml = '''
             <p>
               <hyperlink id="foobar">
                 <r>
@@ -991,15 +1009,14 @@ class HyperlinkTestCase(DocumentGeneratorTestCase):
             </p>
         '''
 
-        expected_html = '<p>link.</p>'
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
 
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-        )
+        expected_html = '<p>link.</p>'
+        self.assert_document_generates_html(document, expected_html)
 
     def test_with_line_break(self):
-        xml_body = '''
+        document_xml = '''
             <p>
               <hyperlink id="foobar">
                 <r>
@@ -1014,15 +1031,15 @@ class HyperlinkTestCase(DocumentGeneratorTestCase):
             </p>
         '''
 
-        expected_html = '<p><a href="http://google.com">li<br />nk</a>.</p>'
-
-        relationships = '''
-            <Relationship Id="foobar" Type="foo/hyperlink"
-                Target="http://google.com" TargetMode="External" />
-        '''
-
-        self.assert_xml_body_matches_expected_html(
-            body=xml_body,
-            expected=expected_html,
-            word_relationships=relationships,
+        document = WordprocessingDocumentFactory()
+        document_rels = document.relationship_format.format(
+            id='foobar',
+            type='foo/hyperlink',
+            target='http://google.com',
+            target_mode='External',
         )
+
+        document.add(MainDocumentPart, document_xml, document_rels)
+
+        expected_html = '<p><a href="http://google.com">li<br />nk</a>.</p>'
+        self.assert_document_generates_html(document, expected_html)

--- a/pydocx/tests/test_html.py
+++ b/pydocx/tests/test_html.py
@@ -81,7 +81,7 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
             </p>
             <p>Footnotes should appear below this</p>
             <hr/>
-            <ol>
+            <ol type="1">
                 <li><p><strong>
                     <a href="#footnote-ref-abc" name="footnote-abc">^</a>
                     Bar
@@ -146,7 +146,7 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
             </p>
             <p>Footnotes should appear below this</p>
             <hr/>
-            <ol>
+            <ol type="1">
                 <li>
                     <p>
                         <a href="#footnote-ref-abc" name="footnote-abc">^</a>
@@ -243,7 +243,7 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
             </p>
             <p>Footnotes should appear below this</p>
             <hr/>
-            <ol>
+            <ol type="1">
                 <li><p>
                     <a href="#footnote-ref-one" name="footnote-one">^</a>
                     Alpha

--- a/pydocx/tests/test_html.py
+++ b/pydocx/tests/test_html.py
@@ -34,7 +34,7 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
         expected_html = '<p>Foo</p>'
         self.assert_document_generates_html(document, expected_html)
 
-    def test_basic_footnote(self):
+    def test_basic_footnote_with_styling(self):
         document_xml = '''
             <p>
               <r>
@@ -47,12 +47,21 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
                 <footnoteReference id="abc"/>
               </r>
             </p>
+            <p>
+              <r>
+                <t>Footnotes should appear below this</t>
+              </r>
+            </p>
         '''
 
         footnotes_xml = '''
             <footnote id="abc">
               <p>
                 <r>
+                  <rPr>
+                    <b val="on"/>
+                  </rPr>
+                  <footnoteRef/>
                   <t>Bar</t>
                 </r>
               </p>
@@ -64,9 +73,11 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
         document.add(MainDocumentPart, document_xml)
 
         expected_html = '''
-            <p>Foo<sup><a href="#footnote-1">1</a></sup></p>
+            <p>Foo<sup><a href="#footnote-abc">1</a></sup></p>
+            <p>Footnotes should appear below this</p>
+            <hr/>
             <ol>
-                <li><a name="footnote-1">Bar</a></li>
+                <li><a name="footnote-abc"></a><p><strong>Bar</strong></p></li>
             </ol>
         '''
         self.assert_document_generates_html(document, expected_html)

--- a/pydocx/tests/test_html.py
+++ b/pydocx/tests/test_html.py
@@ -83,7 +83,64 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
         self.assert_document_generates_html(document, expected_html)
 
     def test_footnote_with_hyperlink(self):
-        pass
+        document_xml = '''
+            <p>
+              <r>
+                <t>Foo</t>
+              </r>
+              <r>
+                <rPr>
+                  <vertAlign val="superscript"/>
+                </rPr>
+                <footnoteReference id="abc"/>
+              </r>
+            </p>
+            <p>
+              <r>
+                <t>Footnotes should appear below this</t>
+              </r>
+            </p>
+        '''
+
+        footnotes_xml = '''
+            <footnote id="abc">
+              <p>
+                <r>
+                  <footnoteRef/>
+                </r>
+                <hyperlink id="foobar">
+                  <r>
+                    <t>Bar</t>
+                  </r>
+                </hyperlink>
+              </p>
+            </footnote>
+        '''
+
+        document = WordprocessingDocumentFactory()
+
+        footnotes_rels = document.relationship_format.format(
+            id='foobar',
+            type='foo/hyperlink',
+            target='http://google.com',
+            target_mode='External',
+        )
+
+        document.add(FootnotesPart, footnotes_xml, footnotes_rels)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <p>Foo<sup><a href="#footnote-abc">1</a></sup></p>
+            <p>Footnotes should appear below this</p>
+            <hr/>
+            <ol>
+                <li>
+                    <a name="footnote-abc"></a>
+                    <p><a href="http://google.com">Bar</a></p>
+                </li>
+            </ol>
+        '''
+        self.assert_document_generates_html(document, expected_html)
 
 
 class ParagraphTestCase(DocumentGeneratorTestCase):

--- a/pydocx/tests/test_html.py
+++ b/pydocx/tests/test_html.py
@@ -81,7 +81,7 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
             </p>
             <p>Footnotes should appear below this</p>
             <hr/>
-            <ol type="1">
+            <ol list-style-type="decimal">
                 <li><p><strong>
                     <a href="#footnote-ref-abc" name="footnote-abc">^</a>
                     Bar
@@ -146,7 +146,7 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
             </p>
             <p>Footnotes should appear below this</p>
             <hr/>
-            <ol type="1">
+            <ol list-style-type="decimal">
                 <li>
                     <p>
                         <a href="#footnote-ref-abc" name="footnote-abc">^</a>
@@ -243,7 +243,7 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
             </p>
             <p>Footnotes should appear below this</p>
             <hr/>
-            <ol type="1">
+            <ol list-style-type="decimal">
                 <li><p>
                     <a href="#footnote-ref-one" name="footnote-one">^</a>
                     Alpha

--- a/pydocx/tests/test_html.py
+++ b/pydocx/tests/test_html.py
@@ -73,11 +73,19 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
         document.add(MainDocumentPart, document_xml)
 
         expected_html = '''
-            <p>Foo<sup><a href="#footnote-abc">1</a></sup></p>
+            <p>
+                Foo
+                <sup>
+                    <a href="#footnote-abc" name="footnote-ref-abc">1</a>
+                </sup>
+            </p>
             <p>Footnotes should appear below this</p>
             <hr/>
             <ol>
-                <li><a name="footnote-abc"></a><p><strong>Bar</strong></p></li>
+                <li><p><strong>
+                    <a href="#footnote-ref-abc" name="footnote-abc">^</a>
+                    Bar
+                </strong></p></li>
             </ol>
         '''
         self.assert_document_generates_html(document, expected_html)
@@ -130,13 +138,20 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
         document.add(MainDocumentPart, document_xml)
 
         expected_html = '''
-            <p>Foo<sup><a href="#footnote-abc">1</a></sup></p>
+            <p>
+                Foo
+                <sup>
+                    <a href="#footnote-abc" name="footnote-ref-abc">1</a>
+                </sup>
+            </p>
             <p>Footnotes should appear below this</p>
             <hr/>
             <ol>
                 <li>
-                    <a name="footnote-abc"></a>
-                    <p><a href="http://google.com">Bar</a></p>
+                    <p>
+                        <a href="#footnote-ref-abc" name="footnote-abc">^</a>
+                        <a href="http://google.com">Bar</a>
+                    </p>
                 </li>
             </ol>
         '''
@@ -213,16 +228,34 @@ class FootnoteTestCase(DocumentGeneratorTestCase):
 
         expected_html = '''
             <p>
-                Foo<sup><a href="#footnote-one">1</a></sup>
-                Bar<sup><a href="#footnote-two">2</a></sup>
-                Baz<sup><a href="#footnote-three">3</a></sup>
+                Foo
+                <sup>
+                    <a href="#footnote-one" name="footnote-ref-one">1</a>
+                </sup>
+                Bar
+                <sup>
+                    <a href="#footnote-two" name="footnote-ref-two">2</a>
+                </sup>
+                Baz
+                <sup>
+                    <a href="#footnote-three" name="footnote-ref-three">3</a>
+                </sup>
             </p>
             <p>Footnotes should appear below this</p>
             <hr/>
             <ol>
-                <li><a name="footnote-one"></a><p>Alpha</p></li>
-                <li><a name="footnote-two"></a><p>Beta</p></li>
-                <li><a name="footnote-three"></a><p>Gamma</p></li>
+                <li><p>
+                    <a href="#footnote-ref-one" name="footnote-one">^</a>
+                    Alpha
+                </p></li>
+                <li><p>
+                    <a href="#footnote-ref-two" name="footnote-two">^</a>
+                    Beta
+                </p></li>
+                <li><p>
+                    <a href="#footnote-ref-three" name="footnote-three">^</a>
+                    Gamma
+                </p></li>
             </ol>
         '''
         self.assert_document_generates_html(document, expected_html)

--- a/pydocx/util/zip.py
+++ b/pydocx/util/zip.py
@@ -8,8 +8,7 @@ import zipfile
 from contextlib import contextmanager
 
 try:
-    from cString import StringIO
-    BytesIO = StringIO
+    from cString import StringIO as BytesIO
 except ImportError:
     from io import BytesIO
 

--- a/pydocx/util/zip.py
+++ b/pydocx/util/zip.py
@@ -7,6 +7,12 @@ from __future__ import (
 import zipfile
 from contextlib import contextmanager
 
+try:
+    from cString import StringIO
+    BytesIO = StringIO
+except ImportError:
+    from io import BytesIO
+
 from pydocx.exceptions import MalformedDocxException
 
 
@@ -18,3 +24,27 @@ def ZipFile(path, mode='r'):  # This is not needed in python 3.2+
         raise MalformedDocxException('Passed in document is not a docx')
     yield f
     f.close()
+
+
+def create_zip_archive(paths_to_data):
+    '''
+    Return an in-memory zip archive.
+
+    `paths_to_data` (dictionary) - For each key, value, the key is treated as a
+    path within the zip archive. The value is the data that will be stored at
+    that path specified by the key.
+
+    Each path MUST NOT include an initial '/'. Each path MUST use '/' as a file
+    separator (this is requried by the zip specification).
+
+    paths_to_data = {
+        'path/file.txt': 'hello',
+    }
+    '''
+    archive = BytesIO()
+    with ZipFile(archive, 'w') as zf:
+        for arcname, data in paths_to_data.items():
+            if data is None:
+                continue
+            zf.writestr(arcname, data.encode('utf-8'))
+    return archive

--- a/pydocx/wordml.py
+++ b/pydocx/wordml.py
@@ -137,9 +137,7 @@ class MainDocumentPart(OpenXmlPart):
 
     @property
     def footnotes_part(self):
-        return self.get_parts_of_type(
-            relationship_type=FootnotesPart.relationship_type,
-        )
+        return self.get_part_of_class_type(part_class=FootnotesPart)
 
 
 class WordprocessingDocument(OpenXmlPackage):

--- a/pydocx/wordml.py
+++ b/pydocx/wordml.py
@@ -10,6 +10,22 @@ from pydocx.openxml import (
 )
 
 
+class FootnotesPart(OpenXmlPart):
+    '''
+    Represents a Footnotes part within a Word document container.
+
+    See also: http://msdn.microsoft.com/en-us/library/documentformat.openxml.packaging.footnotespart%28v=office.14%29.aspx  # noqa
+    '''
+
+    relationship_type = '/'.join([
+        'http://schemas.openxmlformats.org',
+        'officeDocument',
+        '2006',
+        'relationships',
+        'footnotes',
+    ])
+
+
 class ImagePart(OpenXmlPart):
     '''
     Represents an image part relationship within a Word document container.
@@ -91,6 +107,7 @@ class MainDocumentPart(OpenXmlPart):
 
     child_part_types = [
         FontTablePart,
+        FootnotesPart,
         ImagePart,
         NumberingDefinitionsPart,
         StyleDefinitionsPart,
@@ -116,6 +133,12 @@ class MainDocumentPart(OpenXmlPart):
     def image_parts(self):
         return self.get_parts_of_type(
             relationship_type=ImagePart.relationship_type,
+        )
+
+    @property
+    def footnotes_part(self):
+        return self.get_parts_of_type(
+            relationship_type=FootnotesPart.relationship_type,
         )
 
 


### PR DESCRIPTION
Reference: ECMA 376 17.11

A basic initial implementation for footnotes.

* This doesn't process `endnotes.xml`
* `numFmt` is ignored and always uses decimals
* Footnotes are always placed at the very end of the document, regardless of `pos`. HTML has no concept of pages, but it could handle the beneath text option.
* `numRestart` and `numStart` are ignored, so the footnotes always start at 1, and never restarts