### PR TITLE
Modified file write parameters to handle python 3

### DIFF
--- a/pydocx/__init__.py
+++ b/pydocx/__init__.py
@@ -34,8 +34,12 @@ def main():
     else:
         print('Only valid parsers are --html and --markdown')
         sys.exit()
-    with open(path_to_html, 'w') as f:
-        f.write(html.encode('utf-8'))
+    if sys.version_info < (3, 0):
+        with open(path_to_html, 'w') as f:
+            f.write(html.encode('utf-8'))
+    else:
+        with open(path_to_html, 'wb') as f:
+            f.write(html.encode('utf-8'))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I am using python3 and was getting the error as
"f.write(html.encode('utf-8'))
TypeError: must be str, not bytes"

In searching for the error, it was found that in python3 that it should be opened in binary mode.
More discussion about it is at : http://stackoverflow.com/questions/5512811/builtins-typeerror-must-be-str-not-bytes