### PR TITLE
Update PyDocX for greater usability as 3rd-party library

### DIFF
--- a/pydocx/DocxParser.py
+++ b/pydocx/DocxParser.py
@@ -6,7 +6,7 @@ from __future__ import (
 )
 
 import copy
-import logging
+#import logging
 import posixpath
 
 from abc import abstractmethod, ABCMeta
@@ -39,8 +39,8 @@ from pydocx.util.xml import (
 )
 from pydocx.wordml import WordprocessingDocument
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger("NewParser")
+#logging.basicConfig(level=logging.DEBUG)
+#logger = logging.getLogger("NewParser")
 
 
 class IterativeXmlParser(object):

--- a/pydocx/DocxParser.py
+++ b/pydocx/DocxParser.py
@@ -6,7 +6,7 @@ from __future__ import (
 )
 
 import copy
-#import logging
+import logging
 import posixpath
 
 from abc import abstractmethod, ABCMeta
@@ -39,8 +39,7 @@ from pydocx.util.xml import (
 )
 from pydocx.wordml import WordprocessingDocument
 
-#logging.basicConfig(level=logging.DEBUG)
-#logger = logging.getLogger("NewParser")
+logger = logging.getLogger("NewParser")
 
 
 class IterativeXmlParser(object):

--- a/pydocx/__init__.py
+++ b/pydocx/__init__.py
@@ -5,6 +5,7 @@ from __future__ import (
 )
 
 import sys
+import logging
 
 from pydocx.parsers import Docx2Html, Docx2Markdown
 
@@ -20,6 +21,7 @@ def docx2markdown(path):
 
 
 def main():
+    logging.basicConfig(level=logging.DEBUG)
     try:
         parser_to_use = sys.argv[1]
         path_to_docx = sys.argv[2]

--- a/pydocx/parsers/Docx2Html.py
+++ b/pydocx/parsers/Docx2Html.py
@@ -32,14 +32,6 @@ class Docx2Html(DocxParser):
         )
         return content
 
-    @property
-    def parsed_without_head(self):
-        content = super(Docx2Html, self).parsed
-        content = "<html><body>{body}</body></html>".format(
-            body=content,
-        )
-        return content
-
     def make_element(self, tag, contents='', attrs=None):
         if attrs:
             attrs = convert_dictionary_to_html_attributes(attrs)

--- a/pydocx/parsers/Docx2Html.py
+++ b/pydocx/parsers/Docx2Html.py
@@ -34,11 +34,7 @@ class Docx2Html(DocxParser):
 
     @property
     def parsed_content(self):
-        content = super(Docx2Html, self).parsed
-        content = "<div>{body}</div>".format(
-            body=content,
-        )
-        return content
+        return super(Docx2Html, self).parsed
 
     def make_element(self, tag, contents='', attrs=None):
         if attrs:

--- a/pydocx/parsers/Docx2Html.py
+++ b/pydocx/parsers/Docx2Html.py
@@ -35,9 +35,9 @@ class Docx2Html(DocxParser):
     @property
     def parsed_without_head(self):
         content = super(Docx2Html, self).parsed
-        content = "<html><body>%(content)s</body></html>" % {
-            'content': content,
-        }
+        content = "<html><body>{body}</body></html>".format(
+            body=content,
+        )
         return content
 
     def make_element(self, tag, contents='', attrs=None):

--- a/pydocx/parsers/Docx2Html.py
+++ b/pydocx/parsers/Docx2Html.py
@@ -31,6 +31,14 @@ class Docx2Html(DocxParser):
         }
         return content
 
+    @property
+    def parsed_without_head(self):
+        content = super(Docx2Html, self).parsed
+        content = "<html><body>%(content)s</body></html>" % {
+            'content': content,
+        }
+        return content
+
     def make_element(self, tag, contents='', attrs=None):
         if attrs:
             attrs = convert_dictionary_to_html_attributes(attrs)

--- a/pydocx/parsers/Docx2Html.py
+++ b/pydocx/parsers/Docx2Html.py
@@ -32,6 +32,14 @@ class Docx2Html(DocxParser):
         )
         return content
 
+    @property
+    def parsed_content(self):
+        content = super(Docx2Html, self).parsed
+        content = "<div>{body}</div>".format(
+            body=content,
+        )
+        return content
+
     def make_element(self, tag, contents='', attrs=None):
         if attrs:
             attrs = convert_dictionary_to_html_attributes(attrs)


### PR DESCRIPTION
Purpose
=======
Remove possible logging redundancy, increase flexibility in parsing as html

Changes
=======
* Remove `logging.basicConfig()`
  - This was causing duplicate werkzeug logs in the OSF
* Add property `parsed_content`
  - Having more than one `<header>` or `<footer>` tag per page isn't allowed, breaks page

Side Effects
==========
`logger.log()`'s will have to be added for continued logging.