### PR TITLE
Rendered HTML must include utf-8 charset header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**dev**
+
+- Specify charset in rendered HTML
+
 **0.4.3**
 
 - Allow a file-like object to be passed into the DocXParser constructor.

--- a/pydocx/__init__.py
+++ b/pydocx/__init__.py
@@ -19,23 +19,28 @@ def docx2markdown(path):
     return Docx2Markdown(path).parsed
 
 
-def main():
-    try:
-        parser_to_use = sys.argv[1]
-        path_to_docx = sys.argv[2]
-        path_to_html = sys.argv[3]
-    except IndexError:
-        print('Must specify which parser as well as the file to convert and the name of the resulting file.')  # noqa
-        sys.exit()
-    if parser_to_use == '--html':
-        html = Docx2Html(path_to_docx).parsed
-    elif parser_to_use == '--markdown':
-        html = Docx2Markdown(path_to_docx).parsed
+def convert(parser_type, docx_path, output_path):
+    if parser_type == '--html':
+        output = Docx2Html(docx_path).parsed
+    elif parser_type == '--markdown':
+        output = Docx2Markdown(docx_path).parsed
     else:
         print('Only valid parsers are --html and --markdown')
         sys.exit()
-    with open(path_to_html, 'wb') as f:
-        f.write(html.encode('utf-8'))
+    with open(output_path, 'wb') as f:
+        f.write(output.encode('utf-8'))
+
+
+def main():
+    try:
+        parser_type = sys.argv[1]
+        docx_path = sys.argv[2]
+        output_path = sys.argv[3]
+    except IndexError:
+        print('Usage: pydocx [--html|--markdown] input.docx output')
+        sys.exit()
+
+    convert(parser_type, docx_path, output_path)
 
 if __name__ == '__main__':
     main()

--- a/pydocx/parsers/Docx2Html.py
+++ b/pydocx/parsers/Docx2Html.py
@@ -45,9 +45,13 @@ class Docx2Html(DocxParser):
         )
 
     def head(self):
+        head = [
+            '<meta charset="utf-8" />',
+            self.style(),
+        ]
         return self.make_element(
             tag='head',
-            contents=self.style(),
+            contents=''.join(head),
         )
 
     def footer(self):

--- a/pydocx/tests/__init__.py
+++ b/pydocx/tests/__init__.py
@@ -52,6 +52,7 @@ STYLE = (
 BASE_HTML = '''
 <html>
     <head>
+    <meta charset="utf-8" />
     %s
     </head>
     <body>%%s</body>
@@ -61,7 +62,7 @@ BASE_HTML = '''
 
 BASE_HTML_NO_STYLE = '''
 <html>
-    <head></head>
+    <head><meta charset="utf-8" /></head>
     <body>%s</body>
 </html>
 '''

--- a/pydocx/tests/test_html.py
+++ b/pydocx/tests/test_html.py
@@ -294,7 +294,7 @@ class ParagraphTestCase(DocumentGeneratorTestCase):
         expected_html = ''
         self.assert_document_generates_html(document, expected_html)
 
-    def test_unicode_character(self):
+    def test_unicode_character_from_xml_entity(self):
         document_xml = '''
             <p>
               <r>
@@ -306,6 +306,21 @@ class ParagraphTestCase(DocumentGeneratorTestCase):
         document.add(MainDocumentPart, document_xml)
 
         expected_html = '<p>\U0010001f</p>'
+        self.assert_document_generates_html(document, expected_html)
+
+    def test_non_entity_unicode_character(self):
+        document_xml = '''
+            <p>
+              <r>
+                <t>capacités</t>
+              </r>
+            </p>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '<p>capacités</p>'
         self.assert_document_generates_html(document, expected_html)
 
 

--- a/pydocx/tests/test_html.py
+++ b/pydocx/tests/test_html.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 from __future__ import (
     absolute_import,
     print_function,


### PR DESCRIPTION
The HTML rendered using `pydocx --html test.docx output.html` doesn't specify `utf-8` charset even though we output `utf-8`, so we end up with results like the following:

![screenshot from 2015-03-09 12 05 19](https://cloud.githubusercontent.com/assets/243791/6558776/a27518a6-c654-11e4-897d-932ea49e93b5.png)

That should instead look like:

![screenshot from 2015-03-09 12 07 58](https://cloud.githubusercontent.com/assets/243791/6558832/efda38c4-c654-11e4-94a5-3e0e0f13a00d.png)

