### PR TITLE
Update documentation to indicate what portions of the ECMA numbering spec are actually supported

### DIFF
--- a/docs/conformance.rst
+++ b/docs/conformance.rst
@@ -1,0 +1,42 @@
+###########
+Conformance
+###########
+
+Open Office XML is standardized by
+`ECMA-376 <http://www.ecma-international.org/publications/standards/Ecma-376.htm>`_.
+
+To the greatest degree possible,
+PyDocX intends to conform with this
+and subsequent standards.
+
+Deviations
+##########
+
+In some cases,
+it was necessary to deviate
+from the specification.
+Such deviations
+should be only done
+with justification,
+and minimally.
+All intended deviations
+shall be documented here.
+Any undocumented deviations
+are bugs.
+
+Missing val attribute in underline tag
+======================================
+
+* In the event that the
+  ``val`` attribute
+  is missing
+  from a ``u`` (``ST_Underline`` type),
+  we treat the underline as off,
+  or none.
+  See also
+  http://msdn.microsoft.com/en-us/library/ff532016%28v=office.12%29.aspx
+
+   If the val attribute is not specified,
+   Word defaults to the value defined
+   in the style hierarchy
+   and then to no underline.

--- a/docs/conformance.rst
+++ b/docs/conformance.rst
@@ -9,6 +9,43 @@ To the greatest degree possible,
 PyDocX intends to conform with this
 and subsequent standards.
 
+17.9 Numbering
+##############
+
+======= ============================================= ===========
+Section Description                                   Implemented
+======= ============================================= ===========
+17.9.1  abstractNum                                   true
+17.9.2  abstractNumId                                 true
+17.9.3  ilvl                                          true
+17.9.4  isLgl                                         false
+17.9.5  lvl (override)                                false
+17.9.6  lvl                                           true
+17.9.7  lvlJc                                         false
+17.9.8  lvlOverride                                   false
+17.9.9  lvlPictPulletId                               false
+17.9.10 lvlRestart                                    false
+17.9.11 lvlText                                       false
+17.9.12 multiLevelType                                false
+17.9.13 name                                          false
+17.9.14 nsid                                          false
+17.9.15 num                                           true
+17.9.16 numbering                                     true
+17.9.17 numFmt                                        true
+17.9.18 numId                                         true
+17.9.19 numIdMacAtCleanup                             false
+17.9.20 numPicBullet                                  false
+17.9.21 numStyleLink                                  false
+17.9.22 pPr                                           false
+17.9.23 pStyle                                        false
+17.9.24 rPr                                           false
+17.9.25 start                                         false
+17.9.26 startOverride                                 false
+17.9.27 styleLink                                     false
+17.9.28 suff                                          false
+17.9.29 tmpl                                          false
+======= ============================================= ===========
+
 Deviations
 ##########
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ PyDocX
 
    installation
    usage
+   conformance
    extending
    development
    release_notes

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -142,23 +142,3 @@ Exceptions
 
 There is only one custom exception (``MalformedDocxException``).
 It is raised if either the ``xml`` or ``zipfile`` libraries raise an exception.
-
-Deviations from the `ECMA-376 <http://www.ecma-international.org/publications/standards/Ecma-376.htm>`_ Specification
-#####################################################################################################################
-
-Missing val attribute in underline tag
-======================================
-
-* In the event that the
-  ``val`` attribute
-  is missing
-  from a ``u`` (``ST_Underline`` type),
-  we treat the underline as off,
-  or none.
-  See also
-  http://msdn.microsoft.com/en-us/library/ff532016%28v=office.12%29.aspx
-
-   If the val attribute is not specified,
-   Word defaults to the value defined
-   in the style hierarchy
-   and then to no underline.


### PR DESCRIPTION
I was thinking of using a table. Each row would correspond to a particular section in the specification (denoted by the section identifier, such as `17.9.1`), followed by a blurb for the section, and then to what degree PyDocX provides support for it. Would be cool if each row could link to some external resource.

Also, it may be useful for top-level sections to display a percentage of support? So `17.9` would display the percentage support of it's sub-level sections.