### PR TITLE
XML models should specify their own tag names, not parents

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@
   now used by ``openxml.wordprocessing.styles.Style``
 - Implemented several model classes for Numbering.
 - Added numbering property to the numbering definitions part.
+- XmlModels now define their own tags
 
 **0.6.0**
 

--- a/pydocx/models.py
+++ b/pydocx/models.py
@@ -74,10 +74,18 @@ class XmlCollection(XmlField):
     An instance of ParkingLot will have an attribute 'cars' that is a list.
     '''
 
-    def __init__(self, name_to_type_map, default=None):
+    def __init__(self, *types, default=None):
         if default is None:
             default = []
         super(XmlCollection, self).__init__(self, default=default)
+        name_to_type_map = {}
+        for type_spec in types:
+            if isinstance(type_spec, tuple):
+                tag_name, model = type_spec
+            else:
+                model = type_spec
+                tag_name = getattr(model, 'XML_TAG')
+            name_to_type_map[tag_name] = model
         self.name_to_type_map = name_to_type_map
 
     def get_handler_for_tag(self, tag):

--- a/pydocx/models.py
+++ b/pydocx/models.py
@@ -8,6 +8,14 @@ from __future__ import (
 from collections import defaultdict
 
 
+class XmlException(Exception):
+    pass
+
+
+class XmlRootElementMismatchException(XmlException):
+    pass
+
+
 class XmlField(object):
     '''
     Represents a generic XML field which can be an attribute or tag.
@@ -126,6 +134,16 @@ class XmlModel(object):
 
     @classmethod
     def load(cls, element):
+        xml_tag_decl = getattr(cls, 'XML_TAG', None)
+        if element is not None and xml_tag_decl:
+            if xml_tag_decl != element.tag:
+                raise XmlRootElementMismatchException(
+                    'Expected root element {tag} but got {other} instead'.format(  # noqa
+                        tag=xml_tag_decl,
+                        other=element.tag,
+                    ),
+                )
+
         attribute_fields = {}
         tag_fields = {}
         collections = {}

--- a/pydocx/models.py
+++ b/pydocx/models.py
@@ -56,21 +56,36 @@ class XmlChild(XmlField):
 
 class XmlCollection(XmlField):
     '''
-    Represents a collection of elements. To define a field of this type,
-    a mapping dictionary must be passed in specifying the name of the child
-    elements and a callable handler for each.
+    Represents an ordered collection of elements.
 
-    Example:
+    To define a field of this type, pass in a sequence of tuples that specify
+    the tag name of the XML child, and the callable handler:
 
     class ParkingLot(XmlModel):
-        cars = Collection({
-            'car': Car,
-            'truck': Truck,
-        })
+        cars = Collection(
+            ('car', Car),
+            ('truck', Truck),
+        )
 
-    In the above example, 'car' and 'truck' are element names. 'Car' and
+    Alternatively, the callable handlers define their own XML_TAG declaration.
+    In this case, simply pass in the sequence of handlers:
+
+    class Car(XmlModel):
+        XML_TAG = 'car'
+
+    class Truck(XmlModel):
+        XML_TAG = 'truck'
+
+    class ParkingLot(XmlModel):
+        cars = Collection(
+            Car,
+            Truck,
+        )
+
+    In the above examples, 'car' and 'truck' are element names. 'Car' and
     'Truck' are (callable) handlers for those elements. The handler may
     optionally be a XmlModel.
+
     An instance of ParkingLot will have an attribute 'cars' that is a list.
     '''
 

--- a/pydocx/models.py
+++ b/pydocx/models.py
@@ -109,10 +109,10 @@ class XmlModel(object):
             kwargs=', '.join('{field}={value}'.format(
                 field=field,
                 value=repr(value),
-            ) for field, value in self.items()),
+            ) for field, value in self),
         )
 
-    def items(self):
+    def __iter__(self):
         '''
         A generator that loops through each of the defined fields for the
         model, and yields back only those fields which have been set to a value

--- a/pydocx/models.py
+++ b/pydocx/models.py
@@ -89,9 +89,8 @@ class XmlCollection(XmlField):
     An instance of ParkingLot will have an attribute 'cars' that is a list.
     '''
 
-    def __init__(self, *types, default=None):
-        if default is None:
-            default = []
+    def __init__(self, *types, **kwargs):
+        default = kwargs.pop('default', [])
         super(XmlCollection, self).__init__(self, default=default)
         name_to_type_map = {}
         for type_spec in types:

--- a/pydocx/models.py
+++ b/pydocx/models.py
@@ -180,11 +180,19 @@ class XmlModel(object):
 
         # Evaluate the child tags
         for field_name, field in tag_fields.items():
-            # By default, the name is whatever the field name is, unless the
-            # tag definition specifies an override name
+            # The attribute name is whatever the field name is, unless:
+            # field.name is set, or
+            # field.type.XML_TAG is set
             tag_name = field_name
+
             if field.name is not None:
                 tag_name = field.name
+            elif field.type:
+                field_type_tag = getattr(field.type, 'XML_TAG', None)
+                if field_type_tag:
+                    tag_name = field_type_tag
+
+            assert tag_name
 
             # Based on the tag name, we need to know what the field name is
             tag_name_to_field_name[tag_name] = field_name

--- a/pydocx/openxml/packaging/style_definitions_part.py
+++ b/pydocx/openxml/packaging/style_definitions_part.py
@@ -95,7 +95,7 @@ class StyleDefinitionsPart(OpenXmlPart):
         run_properties = {}
         for style in reversed(style_stack):
             if style and style.run_properties:
-                run_properties.update(dict(style.run_properties.items()))
+                run_properties.update(dict(style.run_properties))
         return run_properties
 
     def _resolve_properties_for_element(self, element):
@@ -125,7 +125,7 @@ class StyleDefinitionsPart(OpenXmlPart):
                 )
                 properties_dict.update(run_properties_dict)
             if style_type == 'character':
-                properties_dict.update(dict(properties.items()))
+                properties_dict.update(dict(properties))
         return properties_dict
 
     def get_resolved_properties_for_element(self, el, stack):

--- a/pydocx/openxml/wordprocessing/abstract_num.py
+++ b/pydocx/openxml/wordprocessing/abstract_num.py
@@ -10,9 +10,9 @@ from pydocx.openxml.wordprocessing.level import Level
 
 
 class AbstractNum(XmlModel):
+    XML_TAG = 'abstractNum'
+
     abstract_num_id = XmlAttribute(name='abstractNumId')
     name = XmlChild(attrname='val')
 
-    levels = XmlCollection({
-        'lvl': Level,
-    })
+    levels = XmlCollection(Level)

--- a/pydocx/openxml/wordprocessing/level.py
+++ b/pydocx/openxml/wordprocessing/level.py
@@ -11,10 +11,12 @@ from pydocx.openxml.wordprocessing.paragraph_properties import ParagraphProperti
 
 
 class Level(XmlModel):
+    XML_TAG = 'lvl'
+
     level_id = XmlAttribute(name='ilvl')
     start = XmlChild(attrname='val')
     num_format = XmlChild(name='numFmt', attrname='val')
     restart = XmlChild(name='lvlRestart', attrname='val')
     paragraph_style = XmlChild(name='pStyle', attrname='val')
-    run_properties = XmlChild(type=RunProperties, name='rPr')
-    paragraph_properties = XmlChild(type=ParagraphProperties, name='pPr')
+    run_properties = XmlChild(type=RunProperties)
+    paragraph_properties = XmlChild(type=ParagraphProperties)

--- a/pydocx/openxml/wordprocessing/level_override.py
+++ b/pydocx/openxml/wordprocessing/level_override.py
@@ -10,6 +10,8 @@ from pydocx.openxml.wordprocessing.level import Level
 
 
 class LevelOverride(XmlModel):
+    XML_TAG = 'lvlOverride'
+
     level_id = XmlAttribute(name='ilvl')
     start_override = XmlChild(name='startOverride', attrname='val')
-    level = XmlChild(type=Level, name='lvl')
+    level = XmlChild(type=Level)

--- a/pydocx/openxml/wordprocessing/numbering.py
+++ b/pydocx/openxml/wordprocessing/numbering.py
@@ -11,7 +11,6 @@ from pydocx.openxml.wordprocessing.numbering_instance import NumberingInstance
 
 
 class Numbering(XmlModel):
-    elements = XmlCollection({
-        'abstractNum': AbstractNum,
-        'num': NumberingInstance,
-    })
+    XML_TAG = 'numbering'
+
+    elements = XmlCollection(AbstractNum, NumberingInstance)

--- a/pydocx/openxml/wordprocessing/numbering_instance.py
+++ b/pydocx/openxml/wordprocessing/numbering_instance.py
@@ -10,9 +10,9 @@ from pydocx.openxml.wordprocessing.level_override import LevelOverride
 
 
 class NumberingInstance(XmlModel):
+    XML_TAG = 'num'
+
     num_id = XmlAttribute(name='numId')
     abstract_num_id = XmlChild(name='abstractNumId', attrname='val')
 
-    level_overrides = XmlCollection({
-        'lvlOverride': LevelOverride,
-    })
+    level_overrides = XmlCollection(LevelOverride)

--- a/pydocx/openxml/wordprocessing/paragraph_properties.py
+++ b/pydocx/openxml/wordprocessing/paragraph_properties.py
@@ -9,4 +9,6 @@ from pydocx.models import XmlModel, XmlChild
 
 
 class ParagraphProperties(XmlModel):
+    XML_TAG = 'pPr'
+
     parent_style = XmlChild(name='pStyle', attrname='val')

--- a/pydocx/openxml/wordprocessing/run_properties.py
+++ b/pydocx/openxml/wordprocessing/run_properties.py
@@ -10,6 +10,8 @@ from pydocx.types import OnOff, Underline
 
 
 class RunProperties(XmlModel):
+    XML_TAG = 'rPr'
+
     bold = XmlChild(type=OnOff, name='b', attrname='val')
     italic = XmlChild(type=OnOff, name='i', attrname='val')
     underline = XmlChild(type=Underline, name='u', attrname='val')

--- a/pydocx/openxml/wordprocessing/style.py
+++ b/pydocx/openxml/wordprocessing/style.py
@@ -10,8 +10,10 @@ from pydocx.openxml.wordprocessing.run_properties import RunProperties
 
 
 class Style(XmlModel):
+    XML_TAG = 'style'
+
     style_type = XmlAttribute(name='type', default='paragraph')
     style_id = XmlAttribute(name='styleId', default='')
     name = XmlChild(attrname='val', default='')
-    run_properties = XmlChild(type=RunProperties, name='rPr')
+    run_properties = XmlChild(type=RunProperties)
     parent_style = XmlChild(name='basedOn', attrname='val')

--- a/pydocx/openxml/wordprocessing/styles.py
+++ b/pydocx/openxml/wordprocessing/styles.py
@@ -12,9 +12,9 @@ from pydocx.openxml.wordprocessing.style import Style
 
 
 class Styles(XmlModel):
-    styles = XmlCollection({
-        'style': Style,
-    })
+    XML_TAG = 'styles'
+
+    styles = XmlCollection(Style)
 
     def __init__(self, styles=None):
         super(Styles, self).__init__(styles=styles)

--- a/tests/openxml/wordprocessing/test_run_properties.py
+++ b/tests/openxml/wordprocessing/test_run_properties.py
@@ -44,7 +44,7 @@ class RunPropertiesTestCase(TestCase):
             </rPr>
         '''
         properties = self._load_styles_from_xml(xml)
-        result = dict(properties.items())
+        result = dict(properties)
         self.assertEqual(
             sorted(result.keys()),
             sorted(['bold', 'italic']),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,14 @@ from __future__ import (
 
 from unittest import TestCase
 
-from pydocx.models import XmlModel, XmlCollection, XmlChild, XmlAttribute
+from pydocx.models import (
+    XmlModel,
+    XmlCollection,
+    XmlChild,
+    XmlAttribute,
+    XmlRootElementMismatchException,
+)
+
 from pydocx.util.xml import parse_xml_from_string
 
 
@@ -121,6 +128,14 @@ class XmlChildTestCase(BaseTestCase):
         '''
         bucket = self._get_model_instance_from_xml(xml)
         self.assertEqual(bucket.properties.color, 'blue')
+
+    def test_failure_if_root_tag_mismatch(self):
+        xml = '<notabucket />'
+        try:
+            self._get_model_instance_from_xml(xml)
+            raise AssertionError('Expected XmlRootElementMismatchException')
+        except XmlRootElementMismatchException:
+            pass
 
 
 class XmlCollectionTestCase(BaseTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,11 +26,20 @@ class ItemsModel(XmlModel):
     })
 
 
+class PropertiesModel(XmlModel):
+    XML_TAG = 'prop'
+
+    color = XmlChild(attrname='val')
+
+
 class BucketModel(XmlModel):
     items = XmlChild(type=ItemsModel)
 
     agua = XmlChild(name='water')
     attr_child = XmlChild(attrname='foo')
+
+    # tag name is set by the Model itself via the XML_TAG attribute
+    properties = XmlChild(type=PropertiesModel)
 
 
 class BaseTestCase(TestCase):
@@ -93,6 +102,17 @@ class XmlChildTestCase(BaseTestCase):
         xml = '<bucket />'
         bucket = self._get_model_instance_from_xml(xml)
         self.assertEqual(bucket.attr_child, None)
+
+    def test_child_determines_tag_name(self):
+        xml = '''
+            <bucket>
+                <prop>
+                    <color val="blue" />
+                </prop>
+            </bucket>
+        '''
+        bucket = self._get_model_instance_from_xml(xml)
+        self.assertEqual(bucket.properties.color, 'blue')
 
 
 class XmlCollectionTestCase(BaseTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -33,10 +33,10 @@ class OrangeModel(XmlModel):
 class ItemsModel(XmlModel):
     XML_TAG = 'items'
 
-    items = XmlCollection({
-        'apple': AppleModel,
-        'orange': OrangeModel,
-    })
+    items = XmlCollection(
+        ('apple', AppleModel),
+        OrangeModel,
+    )
 
 
 class PropertiesModel(XmlModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,14 +12,20 @@ from pydocx.util.xml import parse_xml_from_string
 
 
 class AppleModel(XmlModel):
+    XML_TAG = 'apple'
+
     type = XmlAttribute(default='Honey Crisp')
 
 
 class OrangeModel(XmlModel):
+    XML_TAG = 'orange'
+
     type = XmlAttribute(default='Organic')
 
 
 class ItemsModel(XmlModel):
+    XML_TAG = 'items'
+
     items = XmlCollection({
         'apple': AppleModel,
         'orange': OrangeModel,
@@ -33,6 +39,8 @@ class PropertiesModel(XmlModel):
 
 
 class BucketModel(XmlModel):
+    XML_TAG = 'bucket'
+
     items = XmlChild(type=ItemsModel)
 
     agua = XmlChild(name='water')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -124,9 +124,13 @@ class XmlChildTestCase(BaseTestCase):
                 <prop>
                     <color val="blue" />
                 </prop>
+                <properties>
+                    <color val="black" />
+                </properties>
             </bucket>
         '''
         bucket = self._get_model_instance_from_xml(xml)
+        # the properties tag is ignored because the PropertiesModel uses prop
         self.assertEqual(bucket.properties.color, 'blue')
 
     def test_failure_if_root_tag_mismatch(self):

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ envlist = docs, py{27,34}pep8, py{26,27,33,34,py}, py{26,27,33,34,py}-defusedxml
 commands =
   nosetests --with-doctest []
 deps =
-   -rrequirements/testing.txt
-   defusedxml: defusedxml==0.4.1
+  -rrequirements/testing.txt
+  defusedxml: defusedxml==0.4.1
 
 [testenv:docs]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = docs, py{27,34}pep8, py{26,27,33,34,py}, py{26,27,33,34,py}-defusedxml
 
 [testenv]
 commands =
-  nosetests --with-doctest
+  nosetests --with-doctest []
 deps =
    -rrequirements/testing.txt
    defusedxml: defusedxml==0.4.1


### PR DESCRIPTION
Currently, the tag handled by a child is dictated by the parent. This is backwards. The child should be aware of the tag that it handles. 