### PR TITLE
Make importing PyDocX easier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@
 - Implemented several model classes for Numbering.
 - Added numbering property to the numbering definitions part.
 - XmlModels now define their own tags
+- Simplified importing PyDocX
 
 **0.6.0**
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -24,7 +24,7 @@ helper method:
 
 .. code-block:: python
 
-    from pydocx.pydocx import PyDocX
+    from pydocx import PyDocX
 
     # Pass in a path
     html = PyDocX.to_html('file.docx')

--- a/pydocx/__init__.py
+++ b/pydocx/__init__.py
@@ -1,1 +1,9 @@
+from __future__ import absolute_import
+
+from pydocx.pydocx import PyDocX
+
+__all__ = [
+    'PyDocX',
+]
+
 __version__ = '0.6.0'

--- a/pydocx/__main__.py
+++ b/pydocx/__main__.py
@@ -7,7 +7,7 @@ from __future__ import (
 import sys
 import logging
 
-from pydocx.pydocx import PyDocX
+from pydocx import PyDocX
 
 
 def convert(output_type, docx_path, output_path):


### PR DESCRIPTION
Currently you have to do `from pydocx.pydocx import PyDocX` which is somewhat redundant. Make it simpler: `from pydocx import PyDocX`