### PR TITLE
Decouple header processing from the pre-processor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@
 - Added numbering property to the numbering definitions part.
 - XmlModels now define their own tags
 - Simplified importing PyDocX
+- Header processing now occurs in the exporter rather than the pre-processor
 
 **0.6.0**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,11 @@
 - XmlModels now define their own tags
 - Simplified importing PyDocX
 - Header processing now occurs in the exporter rather than the pre-processor
+- PyDocXExporter.heading signature has changed from accepting
+  heading_level which was an HTML tag
+  to accepting
+  heading_style_name
+  which is the raw style name of the heading.
 
 **0.6.0**
 

--- a/pydocx/constants.py
+++ b/pydocx/constants.py
@@ -4,7 +4,7 @@ from __future__ import (
     unicode_literals,
 )
 
-UPPER_ROMAN_TO_HEADING_VALUE = 'h2'
+UPPER_ROMAN_TO_HEADING_VALUE = 'heading 2'
 TAGS_CONTAINING_CONTENT = (
     't',
     'pict',

--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -267,7 +267,6 @@ class PyDocXExporter(MultiMemoizeMixin):
 
         self.pre_processor = self.pre_processor_class(
             convert_root_level_upper_roman=self.convert_root_level_upper_roman,
-            styles=self.document.main_document_part.style_definitions_part.styles,  # noqa
             numbering_root=self.numbering_root,
         )
         self.pre_processor.perform_pre_processing(main_document_part.root_element)  # noqa

--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -201,12 +201,12 @@ class PyDocXExporter(MultiMemoizeMixin):
     def parse_run_properties(self, el, parsed, stack):
         properties = RunProperties.load(el)
         parent = stack[-1]['element']
-        self.document.main_document_part.style_definitions_part.save_properties_for_element(parent, properties)  # noqa
+        self.style_definitions_part.save_properties_for_element(parent, properties)  # noqa
 
     def parse_paragraph_properties(self, el, parsed, stack):
         properties = ParagraphProperties.load(el)
         parent = stack[-1]['element']
-        self.document.main_document_part.style_definitions_part.save_properties_for_element(parent, properties)  # noqa
+        self.style_definitions_part.save_properties_for_element(parent, properties)  # noqa
 
     @property
     def document(self):
@@ -233,18 +233,15 @@ class PyDocXExporter(MultiMemoizeMixin):
             return self.main_document_part.numbering_definitions_part
 
     def _load(self):
-        self.document = WordprocessingDocument(path=self.path)
-        main_document_part = self.document.main_document_part
-        if main_document_part is None:
+        if self.main_document_part is None:
             raise MalformedDocxException
 
         self.numbering_root = None
-        numbering_part = main_document_part.numbering_definitions_part
-        if numbering_part:
-            self.numbering_root = numbering_part.root_element
+        if self.numbering_definitions_part:
+            self.numbering_root = self.numbering_definitions_part.root_element
 
-        self.page_width = self._get_page_width(main_document_part.root_element)
-        self.parse_begin(main_document_part)
+        self.page_width = self._get_page_width(self.main_document_part.root_element)  # noqa
+        self.parse_begin(self.main_document_part)
 
     def load_footnotes(self, main_document_part):
         footnotes = {}

--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -171,6 +171,8 @@ class PyDocXExporter(MultiMemoizeMixin):
         self.footnote_ordering = []
         self.current_part = None
 
+        self._document = None
+
         self.parse_tag_evaluator_mapping = {
             'br': self.parse_break_tag,
             'delText': self.parse_deletion,
@@ -205,6 +207,30 @@ class PyDocXExporter(MultiMemoizeMixin):
         properties = ParagraphProperties.load(el)
         parent = stack[-1]['element']
         self.document.main_document_part.style_definitions_part.save_properties_for_element(parent, properties)  # noqa
+
+    @property
+    def document(self):
+        if self._document:
+            return self._document
+        return self.load_document()
+
+    def load_document(self):
+        self._document = WordprocessingDocument(path=self.path)
+        return self._document
+
+    @property
+    def main_document_part(self):
+        return self.document.main_document_part
+
+    @property
+    def style_definitions_part(self):
+        if self.main_document_part:
+            return self.main_document_part.style_definitions_part
+
+    @property
+    def numbering_definitions_part(self):
+        if self.main_document_part:
+            return self.main_document_part.numbering_definitions_part
 
     def _load(self):
         self.document = WordprocessingDocument(path=self.path)

--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -211,12 +211,16 @@ class PyDocXExporter(MultiMemoizeMixin):
     @property
     def document(self):
         if not self._document:
-            self._document = self.load_document()
+            self.document = self.load_document()
         return self._document
 
+    @document.setter
+    def document(self, document):
+        self._document = document
+
     def load_document(self):
-        self._document = WordprocessingDocument(path=self.path)
-        return self._document
+        self.document = WordprocessingDocument(path=self.path)
+        return self.document
 
     @property
     def main_document_part(self):

--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -210,9 +210,9 @@ class PyDocXExporter(MultiMemoizeMixin):
 
     @property
     def document(self):
-        if self._document:
-            return self._document
-        return self.load_document()
+        if not self._document:
+            self._document = self.load_document()
+        return self._document
 
     def load_document(self):
         self._document = WordprocessingDocument(path=self.path)

--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -466,9 +466,6 @@ class PyDocXExporter(MultiMemoizeMixin):
     def style_name_is_a_heading_level(self, style_name):
         return style_name and style_name.startswith('heading')
 
-    def get_heading_level_for_style_name(self, style_name):
-        return style_name
-
     def get_heading_style_name(self, el):
         properties = self.style_definitions_part.properties_for_elements.get(el)  # noqa
 

--- a/pydocx/export/html.py
+++ b/pydocx/export/html.py
@@ -22,6 +22,30 @@ from pydocx.util.xml import (
 
 class PyDocXHTMLExporter(PyDocXExporter):
 
+    def __init__(self, *args, **kwargs):
+        super(PyDocXHTMLExporter, self).__init__(*args, **kwargs)
+        self.heading_level_conversion_map = {
+            'heading 1': 'h1',
+            'heading 2': 'h2',
+            'heading 3': 'h3',
+            'heading 4': 'h4',
+            'heading 5': 'h5',
+            'heading 6': 'h6',
+        }
+        self.default_heading_level = 'h6'
+
+    def load_document(self):
+        document = super(PyDocXHTMLExporter, self).load_document()
+
+        # Disable character styling for headers
+        if self.style_definitions_part:
+            for style in self.style_definitions_part.styles.styles:
+                style_name = style.name.lower()
+                if self.style_name_is_a_heading_level(style_name):
+                    style.run_properties = None
+
+        return document
+
     @property
     def parsed(self):
         content = super(PyDocXHTMLExporter, self).parsed
@@ -148,7 +172,11 @@ class PyDocXHTMLExporter(PyDocXExporter):
             contents=text,
         )
 
-    def heading(self, text, heading_value):
+    def heading(self, text, heading_style_name):
+        heading_value = self.heading_level_conversion_map.get(
+            heading_style_name,
+            self.default_heading_level,
+        )
         return self.make_element(
             tag=heading_value,
             contents=text,

--- a/pydocx/test/testcases.py
+++ b/pydocx/test/testcases.py
@@ -208,6 +208,7 @@ class DocXFixtureTestCaseFactory(TestCase):
             expected = BASE_HTML % expected
             result = self.convert_docx_to_html(
                 docx_path,
+                # This is set to True for list_to_header
                 convert_root_level_upper_roman=True,
             )
             self.assertHtmlEqual(result, expected)

--- a/pydocx/test/utils.py
+++ b/pydocx/test/utils.py
@@ -282,8 +282,8 @@ class XMLDocx2Html(PyDocXHTMLExporter):
         super(XMLDocx2Html, self).__init__(path=None, *args, **kwargs)
 
     def _load(self):
-        self.document = WordprocessingDocument(path=None)
-        package = self.document.package
+        document = WordprocessingDocument(path=None)
+        package = document.package
         document_part = package.create_part(
             uri='/word/document.xml',
         )
@@ -338,7 +338,8 @@ class XMLDocx2Html(PyDocXHTMLExporter):
         # the page width that we are looking for in the test.
         self.page_width = 612
 
-        self.parse_begin(self.document.main_document_part)
+        self._document = document
+        self.parse_begin(document.main_document_part)
 
     def get_list_style(self, num_id, ilvl):
         try:

--- a/pydocx/test/utils.py
+++ b/pydocx/test/utils.py
@@ -288,8 +288,8 @@ class XMLDocx2Html(PyDocXHTMLExporter):
         # already been loaded.
         # It's likely that we could replace this logic with a
         # WordprocessingDocumentFactory
-        document = WordprocessingDocument(path=None)
-        package = document.package
+        self.document = WordprocessingDocument(path=None)
+        package = self.document.package
         document_part = package.create_part(
             uri='/word/document.xml',
         )
@@ -344,8 +344,7 @@ class XMLDocx2Html(PyDocXHTMLExporter):
         # the page width that we are looking for in the test.
         self.page_width = 612
 
-        self._document = document
-        self.parse_begin(document.main_document_part)
+        self.parse_begin(self.document.main_document_part)
 
     def get_list_style(self, num_id, ilvl):
         try:

--- a/pydocx/test/utils.py
+++ b/pydocx/test/utils.py
@@ -282,6 +282,12 @@ class XMLDocx2Html(PyDocXHTMLExporter):
         super(XMLDocx2Html, self).__init__(path=None, *args, **kwargs)
 
     def _load(self):
+        # TODO Ideally, we could just do package = self.document.package, but
+        # that would cause an empty container to be (forever) loaded, since we
+        # don't have a mechanism for re-validating parts after they have
+        # already been loaded.
+        # It's likely that we could replace this logic with a
+        # WordprocessingDocumentFactory
         document = WordprocessingDocument(path=None)
         package = document.package
         document_part = package.create_part(

--- a/pydocx/util/preprocessor.py
+++ b/pydocx/util/preprocessor.py
@@ -91,7 +91,6 @@ class PydocxPreProcessor(MultiMemoizeMixin):
         self._set_first_list_item(num_ids, ilvls, list_elements)
         self._set_last_list_item(num_ids, list_elements)
 
-        self._set_headers(p_elements)
         self._convert_upper_roman(body)
 
     def is_first_list_item(self, el):
@@ -261,45 +260,6 @@ class PydocxPreProcessor(MultiMemoizeMixin):
         for p in paragraph_elements:
             if find_ancestor_with_tag(self, p, 'tc') is not None:
                 self.meta_data[p]['is_in_table'] = True
-
-    def _set_headers(self, elements):
-        # These are the styles for headers and what the html tag should be if
-        # we have one.
-        headers = {
-            'heading 1': 'h1',
-            'heading 2': 'h2',
-            'heading 3': 'h3',
-            'heading 4': 'h4',
-            'heading 5': 'h5',
-            'heading 6': 'h6',
-            'heading 7': 'h6',
-            'heading 8': 'h6',
-            'heading 9': 'h6',
-            'heading 10': 'h6',
-        }
-        # Remove the rPr from the styles dict since all the styling will be
-        # down with the heading.
-        for style in self.styles.styles:
-            if style.name.lower() in headers:
-                style.run_properties = None
-
-        for element in elements:
-            # This element is using the default style which is not a heading.
-            p_style = element.find('./pPr/pStyle')
-            if p_style is None:
-                continue
-            style = p_style.attrib.get('val', '')
-            style = self.styles.get_styles_by_type('paragraph').get(style)
-            if style:
-                style_name = style.name.lower()
-                # Check to see if this element is actually a header.
-                if style_name in headers:
-                    # Set all the list item variables to false.
-                    self.meta_data[element]['is_list_item'] = False
-                    self.meta_data[element]['is_first_list_item'] = False
-                    self.meta_data[element]['is_last_list_item_in_root'] = False  # noqa
-                    # Prime the heading_level
-                    self.meta_data[element]['heading_level'] = headers[style_name]  # noqa
 
     def _convert_upper_roman(self, body):
         if not self.convert_root_level_upper_roman:

--- a/pydocx/util/preprocessor.py
+++ b/pydocx/util/preprocessor.py
@@ -60,12 +60,10 @@ class PydocxPreProcessor(MultiMemoizeMixin):
     def __init__(
             self,
             convert_root_level_upper_roman=False,
-            styles=None,
             numbering_root=None,
             *args, **kwargs):
         self.meta_data = defaultdict(dict)
         self.convert_root_level_upper_roman = convert_root_level_upper_roman
-        self.styles = styles
         self.numbering_root = numbering_root
 
     def perform_pre_processing(self, root, *args, **kwargs):


### PR DESCRIPTION
The header processing is very HTML-centric, but it lives in the base pre-processor. Decouple this logic from the pre-processor, and split it appropriately between the base exporter and html exporter.