### PR TITLE
Convert the 'Root level upper roman list to header' handling to an optional mixin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,10 @@
   to accepting
   heading_style_name
   which is the raw style name of the heading.
+- The ``convert_root_level_upper_roman``
+  option has been replaced
+  with an optional mixin
+  ``pydocx.export.mixins.ConvertRootUpperRomanListToHeadingMixin``.
 
 **0.6.0**
 

--- a/docs/export_mixins.rst
+++ b/docs/export_mixins.rst
@@ -1,0 +1,61 @@
+#############
+Export Mixins
+#############
+
+Export mixins
+provide standardized
+optional overrides
+for specific use cases.
+They exist in
+``pydocx.export.mixins``.
+Each mixin is defined as a class
+in its own module.
+
+Convert root level upperRoman lists to headings
+###############################################
+
+Useful if you want
+root-level only
+list items
+that are formatted
+with "upperRoman"
+to be treated as headers.
+
+Example usage:
+
+.. code-block:: python
+
+    from pydocx.export.mixins import ConvertRootUpperRomanListToHeadingMixin
+
+
+    class CustomExporter(
+        ConvertRootUpperRomanListToHeadingMixin,
+        PyDocXHTMLExporter,
+    ):
+        pass
+
+Detect faked superscript and subscript
+######################################
+
+Useful if you want
+runs of text
+that are styled smaller
+(relative to surrounding text)
+and positioned
+either above
+or below
+the surrounding text
+to be treated as super/subscript.
+
+Example usage:
+
+.. code-block:: python
+
+    from pydocx.export.mixins import FakedSuperscriptAndSubscriptExportMixin
+
+
+    class CustomExporter(
+        FakedSuperscriptAndSubscriptExportMixin,
+        PyDocXHTMLExporter,
+    ):
+        pass

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -183,13 +183,3 @@ which is called from
 Everything done during pre-processing
 is executed prior to ``parse``
 being called for the first time.
-
-Optional Arguments
-##################
-
-You can pass in
-``convert_root_level_upper_roman=True``
-to the exporter
-and it will convert
-all root level upper roman lists
-to headings.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,5 +8,6 @@ PyDocX
    usage
    conformance
    extending
+   export_mixins
    development
    release_notes

--- a/pydocx/constants.py
+++ b/pydocx/constants.py
@@ -4,7 +4,6 @@ from __future__ import (
     unicode_literals,
 )
 
-UPPER_ROMAN_TO_HEADING_VALUE = 'heading 2'
 TAGS_CONTAINING_CONTENT = (
     't',
     'pict',

--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -493,11 +493,7 @@ class PyDocXExporter(MultiMemoizeMixin):
         # but that is for another ticket.
         text = self.justification(el, text)
 
-        # TODO the pre-processor is still handling the upperRoman list to
-        # header conversion. This should be implemented in a mixin
-        heading_style_name = self.pre_processor.heading_level(el)
-        if not heading_style_name:
-            heading_style_name = self.get_heading_style_name(el)
+        heading_style_name = self.get_heading_style_name(el)
 
         if heading_style_name:
             return self.heading(

--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import (
     absolute_import,
     division,

--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -155,16 +155,11 @@ class PyDocXExporter(MultiMemoizeMixin):
     __metaclass__ = ABCMeta
     pre_processor_class = PydocxPreProcessor
 
-    def __init__(
-        self,
-        path,
-        convert_root_level_upper_roman=False,
-    ):
+    def __init__(self, path):
         self.path = path
         self._parsed = ''
         self.block_text = ''
         self.page_width = 0
-        self.convert_root_level_upper_roman = convert_root_level_upper_roman
         self.pre_processor = None
         self.visited = set()
         self.list_depth = 0
@@ -271,7 +266,6 @@ class PyDocXExporter(MultiMemoizeMixin):
         })
 
         self.pre_processor = self.pre_processor_class(
-            convert_root_level_upper_roman=self.convert_root_level_upper_roman,
             numbering_root=self.numbering_root,
         )
         self.pre_processor.perform_pre_processing(main_document_part.root_element)  # noqa

--- a/pydocx/export/html.py
+++ b/pydocx/export/html.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import (
     absolute_import,
     division,

--- a/pydocx/export/mixins/__init__.py
+++ b/pydocx/export/mixins/__init__.py
@@ -1,7 +1,11 @@
+from pydocx.export.mixins.convert_root_upper_roman_list_to_heading import (
+    ConvertRootUpperRomanListToHeadingMixin,
+)
 from pydocx.export.mixins.faked_superscript_and_subscript import (
     FakedSuperscriptAndSubscriptExportMixin,
 )
 
 __all__ = [
+    'ConvertRootUpperRomanListToHeadingMixin',
     'FakedSuperscriptAndSubscriptExportMixin',
 ]

--- a/pydocx/export/mixins/convert_root_upper_roman_list_to_heading.py
+++ b/pydocx/export/mixins/convert_root_upper_roman_list_to_heading.py
@@ -1,0 +1,29 @@
+# coding: utf-8
+from __future__ import (
+    absolute_import,
+    print_function,
+    unicode_literals,
+)
+
+
+class ConvertRootUpperRomanListToHeadingMixin(object):
+    def parse_p(self, el, text, stack):
+        if text == '':
+            return ''
+
+        # TODO This is being done in the base exporter already
+        justified_text = self.justification(el, text)
+
+        heading_style_name = self.pre_processor.heading_level(el)
+
+        if heading_style_name:
+            return self.heading(
+                text=justified_text,
+                heading_style_name=heading_style_name,
+            )
+
+        return super(ConvertRootUpperRomanListToHeadingMixin, self).parse_p(
+            el,
+            text,
+            stack,
+        )

--- a/pydocx/export/mixins/convert_root_upper_roman_list_to_heading.py
+++ b/pydocx/export/mixins/convert_root_upper_roman_list_to_heading.py
@@ -12,6 +12,8 @@ class ConvertRootUpperRomanListToHeadingMixin(object):
     HEADING_LEVEL = 'heading 2'
 
     def _is_element_a_root_level_upper_roman_list_item(self, el):
+        numbering = self.numbering_definitions_part.numbering
+
         properties = self.style_definitions_part.properties_for_elements.get(el)  # noqa
         num_props = properties.numbering_properties
         if not num_props:
@@ -20,11 +22,11 @@ class ConvertRootUpperRomanListToHeadingMixin(object):
         if not num_props.is_root_level():
             return False
 
-        numbering = self.numbering_definitions_part.numbering
-
         num_definition = numbering.get_numbering_definition(num_id=num_props.num_id)  # noqa
-        level = num_definition.get_level(level_id=num_props.level_id)
+        if not num_definition:
+            return False
 
+        level = num_definition.get_level(level_id=num_props.level_id)
         if not level:
             return False
 

--- a/pydocx/export/mixins/faked_superscript_and_subscript.py
+++ b/pydocx/export/mixins/faked_superscript_and_subscript.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import (
     absolute_import,
     print_function,

--- a/pydocx/openxml/packaging/main_document_part.py
+++ b/pydocx/openxml/packaging/main_document_part.py
@@ -55,7 +55,14 @@ class MainDocumentPart(OpenXmlPart):
 
     @property
     def numbering_definitions_part(self):
-        return self.get_part_of_class_type(part_class=NumberingDefinitionsPart)
+        part = self.get_part_of_class_type(part_class=NumberingDefinitionsPart)
+        if part is None:
+            part = NumberingDefinitionsPart(
+                uri=None,
+                open_xml_package=self.open_xml_package,
+            )
+            self.add_part(part)
+        return part
 
     @property
     def font_table_part(self):

--- a/pydocx/openxml/packaging/numbering_definitions_part.py
+++ b/pydocx/openxml/packaging/numbering_definitions_part.py
@@ -22,13 +22,22 @@ class NumberingDefinitionsPart(OpenXmlPart):
         'numbering',
     ])
 
+    NUM_FORMAT_UPPER_ROMAN = 'upperRoman'
+
     def __init__(self, *args, **kwargs):
         super(NumberingDefinitionsPart, self).__init__(*args, **kwargs)
         self._numbering = None
 
     @property
     def numbering(self):
-        if self._numbering:
-            return self._numbering
-        self._numbering = Numbering.load(self.root_element)
+        if not self._numbering:
+            self.numbering = self.load_numbering()
         return self._numbering
+
+    @numbering.setter
+    def numbering(self, numbering):
+        self._numbering = numbering
+
+    def load_numbering(self):
+        self.numbering = Numbering.load(self.root_element)
+        return self.numbering

--- a/pydocx/openxml/packaging/numbering_definitions_part.py
+++ b/pydocx/openxml/packaging/numbering_definitions_part.py
@@ -31,13 +31,9 @@ class NumberingDefinitionsPart(OpenXmlPart):
     @property
     def numbering(self):
         if not self._numbering:
-            self.numbering = self.load_numbering()
+            self._numbering = self.load_numbering()
         return self._numbering
 
-    @numbering.setter
-    def numbering(self, numbering):
-        self._numbering = numbering
-
     def load_numbering(self):
-        self.numbering = Numbering.load(self.root_element)
-        return self.numbering
+        self._numbering = Numbering.load(self.root_element)
+        return self._numbering

--- a/pydocx/openxml/wordprocessing/__init__.py
+++ b/pydocx/openxml/wordprocessing/__init__.py
@@ -4,6 +4,7 @@ from pydocx.openxml.wordprocessing.level import Level
 from pydocx.openxml.wordprocessing.level_override import LevelOverride
 from pydocx.openxml.wordprocessing.numbering import Numbering
 from pydocx.openxml.wordprocessing.numbering_instance import NumberingInstance
+from pydocx.openxml.wordprocessing.numbering_properties import NumberingProperties  # noqa
 from pydocx.openxml.wordprocessing.paragraph_properties import ParagraphProperties  # noqa
 from pydocx.openxml.wordprocessing.run_properties import RunProperties  # noqa
 from pydocx.openxml.wordprocessing.style import Style
@@ -15,6 +16,7 @@ __all__ = [
     'LevelOverride',
     'Numbering',
     'NumberingInstance',
+    'NumberingProperties',
     'ParagraphProperties',
     'RunProperties',
     'Style',

--- a/pydocx/openxml/wordprocessing/abstract_num.py
+++ b/pydocx/openxml/wordprocessing/abstract_num.py
@@ -16,3 +16,14 @@ class AbstractNum(XmlModel):
     name = XmlChild(attrname='val')
 
     levels = XmlCollection(Level)
+
+    def __init__(self, **kwargs):
+        super(AbstractNum, self).__init__(**kwargs)
+
+        self._levels = {}
+
+        for level in self.levels:
+            self._levels[level.level_id] = level
+
+    def get_level(self, level_id):
+        return self._levels.get(level_id)

--- a/pydocx/openxml/wordprocessing/numbering.py
+++ b/pydocx/openxml/wordprocessing/numbering.py
@@ -14,3 +14,27 @@ class Numbering(XmlModel):
     XML_TAG = 'numbering'
 
     elements = XmlCollection(AbstractNum, NumberingInstance)
+
+    def __init__(self, **kwargs):
+        super(Numbering, self).__init__(**kwargs)
+
+        self._abstract_nums = {}
+        self._nums = {}
+
+        for el in self.elements:
+            if isinstance(el, AbstractNum):
+                self._abstract_nums[el.abstract_num_id] = el
+            elif isinstance(el, NumberingInstance):
+                self._nums[el.num_id] = el
+            else:
+                raise AssertionError(
+                    'Unexpected element type {type} encountered'.format(
+                        type=el.__class__.__name__,
+                    )
+                )
+
+    def get_numbering_definition(self, num_id):
+        num = self._nums.get(num_id)
+        if not num:
+            return
+        return self._abstract_nums.get(num.abstract_num_id)

--- a/pydocx/openxml/wordprocessing/numbering_properties.py
+++ b/pydocx/openxml/wordprocessing/numbering_properties.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+from __future__ import (
+    absolute_import,
+    print_function,
+    unicode_literals,
+)
+
+from pydocx.models import XmlModel, XmlChild
+
+
+class NumberingProperties(XmlModel):
+    XML_TAG = 'numPr'
+
+    ROOT_LEVEL_ID = '0'
+
+    level_id = XmlChild(name='ilvl', attrname='val')
+    num_id = XmlChild(name='numId', attrname='val')
+
+    def is_root_level(self):
+        if self.num_id is None or self.level_id is None:
+            return False
+
+        return self.level_id == self.ROOT_LEVEL_ID

--- a/pydocx/openxml/wordprocessing/paragraph_properties.py
+++ b/pydocx/openxml/wordprocessing/paragraph_properties.py
@@ -6,9 +6,11 @@ from __future__ import (
 )
 
 from pydocx.models import XmlModel, XmlChild
+from pydocx.openxml.wordprocessing.numbering_properties import NumberingProperties  # noqa
 
 
 class ParagraphProperties(XmlModel):
     XML_TAG = 'pPr'
 
     parent_style = XmlChild(name='pStyle', attrname='val')
+    numbering_properties = XmlChild(type=NumberingProperties)

--- a/pydocx/test/testcases.py
+++ b/pydocx/test/testcases.py
@@ -134,7 +134,6 @@ class TranslationTestCase(TestCase):
     run_expected_output = True
     parser = XMLDocx2Html
     use_base_html = True
-    convert_root_level_upper_roman = False
     styles_xml = None
 
     def get_xml(self):
@@ -159,7 +158,6 @@ class TranslationTestCase(TestCase):
         parser = self.parser
 
         html = parser(
-            convert_root_level_upper_roman=self.convert_root_level_upper_roman,
             document_xml=tree,
             relationships=self.relationships,
             numbering_dict=self.numbering_dict,
@@ -206,11 +204,7 @@ class DocXFixtureTestCaseFactory(TestCase):
                 expected = f.read()
 
             expected = BASE_HTML % expected
-            result = self.convert_docx_to_html(
-                docx_path,
-                # This is set to True for list_to_header
-                convert_root_level_upper_roman=True,
-            )
+            result = self.convert_docx_to_html(docx_path)
             self.assertHtmlEqual(result, expected)
         return run_test
 

--- a/pydocx/util/preprocessor.py
+++ b/pydocx/util/preprocessor.py
@@ -102,9 +102,6 @@ class PydocxPreProcessor(MultiMemoizeMixin):
             return None
         return self.meta_data[el].get('ilvl')
 
-    def heading_level(self, el):
-        return self.meta_data[el].get('heading_level')
-
     def is_in_table(self, el):
         return self.meta_data[el].get('is_in_table')
 

--- a/pydocx/util/preprocessor.py
+++ b/pydocx/util/preprocessor.py
@@ -89,8 +89,6 @@ class PydocxPreProcessor(MultiMemoizeMixin):
         self._set_first_list_item(num_ids, ilvls, list_elements)
         self._set_last_list_item(num_ids, list_elements)
 
-        self._convert_upper_roman(body)
-
     def is_first_list_item(self, el):
         return self.meta_data[el].get('is_first_list_item', False)
 
@@ -258,44 +256,6 @@ class PydocxPreProcessor(MultiMemoizeMixin):
         for p in paragraph_elements:
             if find_ancestor_with_tag(self, p, 'tc') is not None:
                 self.meta_data[p]['is_in_table'] = True
-
-    def _convert_upper_roman(self, body):
-        if not self.convert_root_level_upper_roman:
-            return
-        first_root_list_items = [
-            # Only root level elements.
-            el for el in body.getchildren()
-            # And only first_list_items
-            if self.is_first_list_item(el)
-        ]
-        visited_num_ids = []
-        all_p_tags_in_body = find_all(body, 'p')
-        for root_list_item in first_root_list_items:
-            if self.num_id(root_list_item) in visited_num_ids:
-                continue
-            visited_num_ids.append(self.num_id(root_list_item))
-            lst_style = get_list_style(
-                self.numbering_root,
-                self.num_id(root_list_item).num_id,
-                self.ilvl(root_list_item),
-            )
-            if lst_style != 'upperRoman':
-                continue
-            ilvl = min(
-                self.ilvl(el) for el in all_p_tags_in_body
-                if self.num_id(el) == self.num_id(root_list_item)
-            )
-            root_upper_roman_list_items = [
-                el for el in all_p_tags_in_body
-                if self.num_id(el) == self.num_id(root_list_item) and
-                self.ilvl(el) == ilvl
-            ]
-            for list_item in root_upper_roman_list_items:
-                self.meta_data[list_item]['is_list_item'] = False
-                self.meta_data[list_item]['is_first_list_item'] = False
-                self.meta_data[list_item]['is_last_list_item_in_root'] = False  # noqa
-
-                self.meta_data[list_item]['heading_level'] = UPPER_ROMAN_TO_HEADING_VALUE  # noqa
 
     def _set_next(self, body):
         def _get_children_with_content(el):

--- a/pydocx/util/preprocessor.py
+++ b/pydocx/util/preprocessor.py
@@ -7,7 +7,6 @@ from __future__ import (
 from collections import defaultdict
 
 from pydocx.constants import (
-    UPPER_ROMAN_TO_HEADING_VALUE,
     TAGS_HOLDING_CONTENT_TAGS,
     TAGS_CONTAINING_CONTENT,
 )

--- a/pydocx/util/preprocessor.py
+++ b/pydocx/util/preprocessor.py
@@ -57,13 +57,8 @@ class NamespacedNumId(object):
 
 
 class PydocxPreProcessor(MultiMemoizeMixin):
-    def __init__(
-            self,
-            convert_root_level_upper_roman=False,
-            numbering_root=None,
-            *args, **kwargs):
+    def __init__(self, numbering_root=None, *args, **kwargs):
         self.meta_data = defaultdict(dict)
-        self.convert_root_level_upper_roman = convert_root_level_upper_roman
         self.numbering_root = numbering_root
 
     def perform_pre_processing(self, root, *args, **kwargs):

--- a/pydocx/util/preprocessor.py
+++ b/pydocx/util/preprocessor.py
@@ -16,7 +16,6 @@ from pydocx.util.xml import (
     filter_children,
     find_all,
     find_ancestor_with_tag,
-    get_list_style,
     has_descendant_with_tag,
 )
 

--- a/pydocx/util/preprocessor.py
+++ b/pydocx/util/preprocessor.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import (
     absolute_import,
     print_function,

--- a/tests/export/mixins/test_convert_root_upper_roman_list_to_heading.py
+++ b/tests/export/mixins/test_convert_root_upper_roman_list_to_heading.py
@@ -20,24 +20,14 @@ class ConvertRootUpperRomanListToHeadingExporterNoStyle(
     ConvertRootUpperRomanListToHeadingMixin,
     PyDocXHTMLExporterNoStyle,
 ):
-    def __init__(self, *args, **kwargs):
-        kwargs['convert_root_level_upper_roman'] = True
-        super(ConvertRootUpperRomanListToHeadingExporterNoStyle, self).__init__(  # noqa
-            *args,
-            **kwargs
-        )
+    pass
 
 
 class ConvertRootUpperRomanListToHeadingExporter(
     ConvertRootUpperRomanListToHeadingMixin,
     PyDocXHTMLExporter,
 ):
-    def __init__(self, *args, **kwargs):
-        kwargs['convert_root_level_upper_roman'] = True
-        super(ConvertRootUpperRomanListToHeadingExporter, self).__init__(
-            *args,
-            **kwargs
-        )
+    pass
 
 
 class ConvertRootUpperRomanListToHeadingTestCase(DocumentGeneratorTestCase):

--- a/tests/export/mixins/test_convert_root_upper_roman_list_to_heading.py
+++ b/tests/export/mixins/test_convert_root_upper_roman_list_to_heading.py
@@ -32,32 +32,31 @@ class ConvertRootUpperRomanListToHeadingExporter(
 
 class ConvertRootUpperRomanListToHeadingTestCase(DocumentGeneratorTestCase):
     exporter = ConvertRootUpperRomanListToHeadingExporterNoStyle
+    list_item = '''
+        <p>
+          <pPr>
+            <numPr>
+              <ilvl val="{level}"/>
+              <numId val="{num_id}"/>
+            </numPr>
+          </pPr>
+          <r><t>{content}</t></r>
+        </p>
+    '''
 
-    def test_only_root_level_upper_roman_list_converted_to_heading(self):
-        list_item = '''
-            <p>
-              <pPr>
-                <numPr>
-                  <ilvl val="{level}"/>
-                  <numId val="{num_id}"/>
-                </numPr>
-              </pPr>
-              <r><t>{content}</t></r>
-            </p>
-        '''
-
+    def test_only_root_level_upperRoman_list_converted_to_heading(self):
         document_xml = ''.join([
-            list_item.format(
+            self.list_item.format(
                 content='AAA',
                 num_id=1,
                 level=0,
             ),
-            list_item.format(
+            self.list_item.format(
                 content='BBB',
                 num_id=1,
                 level=1,
             ),
-            list_item.format(
+            self.list_item.format(
                 content='CCC',
                 num_id=1,
                 level=2,
@@ -93,6 +92,129 @@ class ConvertRootUpperRomanListToHeadingTestCase(DocumentGeneratorTestCase):
                         <li>CCC</li>
                     </ol>
                 </li>
+            </ol>
+        '''
+        self.assert_document_generates_html(document, expected_html)
+
+    def test_missing_numbering_definition(self):
+        document_xml = ''.join([
+            self.list_item.format(
+                content='AAA',
+                num_id=1,
+                level=0,
+            ),
+        ])
+
+        numbering_xml = ''
+
+        document = WordprocessingDocumentFactory()
+        document.add(NumberingDefinitionsPart, numbering_xml)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <ol class="pydocx-list-style-type-None">
+                <li>AAA</li>
+            </ol>
+        '''
+        self.assert_document_generates_html(document, expected_html)
+
+    def test_missing_numbering_part(self):
+        document_xml = ''.join([
+            self.list_item.format(
+                content='AAA',
+                num_id=1,
+                level=0,
+            ),
+        ])
+
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '<p>AAA</p>'
+        self.assert_document_generates_html(document, expected_html)
+
+    def test_missing_level_definition(self):
+        document_xml = ''.join([
+            self.list_item.format(
+                content='AAA',
+                num_id=1,
+                level=0,
+            ),
+        ])
+
+        numbering_xml = '''
+            <num numId="1">
+              <abstractNumId val="1"/>
+            </num>
+            <abstractNum abstractNumId="1">
+            </abstractNum>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(NumberingDefinitionsPart, numbering_xml)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <ol class="pydocx-list-style-type-None">
+                <li>AAA</li>
+            </ol>
+        '''
+        self.assert_document_generates_html(document, expected_html)
+
+    def test_root_level_upperRoman_list_not_converted_to_heading(self):
+        document_xml = ''.join([
+            self.list_item.format(
+                content='AAA',
+                num_id=1,
+                level=0,
+            ),
+        ])
+
+        numbering_xml = '''
+            <num numId="1">
+              <abstractNumId val="1"/>
+            </num>
+            <abstractNum abstractNumId="1">
+              <lvl ilvl="0">
+                <numFmt val="upperRoman"/>
+              </lvl>
+            </abstractNum>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(NumberingDefinitionsPart, numbering_xml)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '<h2>AAA</h2>'
+        self.assert_document_generates_html(document, expected_html)
+
+    def test_root_level_decimal_list_not_converted_to_heading(self):
+        document_xml = ''.join([
+            self.list_item.format(
+                content='AAA',
+                num_id=1,
+                level=0,
+            ),
+        ])
+
+        numbering_xml = '''
+            <num numId="1">
+              <abstractNumId val="1"/>
+            </num>
+            <abstractNum abstractNumId="1">
+              <lvl ilvl="0">
+                <numFmt val="decimal"/>
+              </lvl>
+            </abstractNum>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(NumberingDefinitionsPart, numbering_xml)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <ol class="pydocx-list-style-type-decimal">
+                <li>AAA</li>
             </ol>
         '''
         self.assert_document_generates_html(document, expected_html)

--- a/tests/export/mixins/test_convert_root_upper_roman_list_to_heading.py
+++ b/tests/export/mixins/test_convert_root_upper_roman_list_to_heading.py
@@ -1,0 +1,120 @@
+# coding: utf-8
+
+from __future__ import (
+    absolute_import,
+    print_function,
+    unicode_literals,
+)
+
+from pydocx.export.html import PyDocXHTMLExporter
+from pydocx.export.mixins import ConvertRootUpperRomanListToHeadingMixin
+from pydocx.test import DocumentGeneratorTestCase, DocXFixtureTestCaseFactory
+from pydocx.test.utils import (
+    PyDocXHTMLExporterNoStyle,
+    WordprocessingDocumentFactory,
+)
+from pydocx.openxml.packaging import MainDocumentPart, NumberingDefinitionsPart
+
+
+class ConvertRootUpperRomanListToHeadingExporterNoStyle(
+    ConvertRootUpperRomanListToHeadingMixin,
+    PyDocXHTMLExporterNoStyle,
+):
+    def __init__(self, *args, **kwargs):
+        kwargs['convert_root_level_upper_roman'] = True
+        super(ConvertRootUpperRomanListToHeadingExporterNoStyle, self).__init__(  # noqa
+            *args,
+            **kwargs
+        )
+
+
+class ConvertRootUpperRomanListToHeadingExporter(
+    ConvertRootUpperRomanListToHeadingMixin,
+    PyDocXHTMLExporter,
+):
+    def __init__(self, *args, **kwargs):
+        kwargs['convert_root_level_upper_roman'] = True
+        super(ConvertRootUpperRomanListToHeadingExporter, self).__init__(
+            *args,
+            **kwargs
+        )
+
+
+class ConvertRootUpperRomanListToHeadingTestCase(DocumentGeneratorTestCase):
+    exporter = ConvertRootUpperRomanListToHeadingExporterNoStyle
+
+    def test_only_root_level_upper_roman_list_converted_to_heading(self):
+        list_item = '''
+            <p>
+              <pPr>
+                <numPr>
+                  <ilvl val="{level}"/>
+                  <numId val="{num_id}"/>
+                </numPr>
+              </pPr>
+              <r><t>{content}</t></r>
+            </p>
+        '''
+
+        document_xml = ''.join([
+            list_item.format(
+                content='AAA',
+                num_id=1,
+                level=0,
+            ),
+            list_item.format(
+                content='BBB',
+                num_id=1,
+                level=1,
+            ),
+            list_item.format(
+                content='CCC',
+                num_id=1,
+                level=2,
+            ),
+        ])
+
+        numbering_xml = '''
+            <num numId="1">
+              <abstractNumId val="1"/>
+            </num>
+            <abstractNum abstractNumId="1">
+              <lvl ilvl="0">
+                <numFmt val="upperRoman"/>
+              </lvl>
+              <lvl ilvl="1">
+                <numFmt val="decimal"/>
+              </lvl>
+              <lvl ilvl="2">
+                <numFmt val="upperRoman"/>
+              </lvl>
+            </abstractNum>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(NumberingDefinitionsPart, numbering_xml)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <h2>AAA</h2>
+            <ol class="pydocx-list-style-type-decimal">
+                <li>BBB
+                    <ol class="pydocx-list-style-type-upperRoman">
+                        <li>CCC</li>
+                    </ol>
+                </li>
+            </ol>
+        '''
+        self.assert_document_generates_html(document, expected_html)
+
+
+class DocXFixtureTestCase(DocXFixtureTestCaseFactory):
+    exporter = ConvertRootUpperRomanListToHeadingExporter
+    cases = (
+        # The list element GGG is expected to be upperRoman.
+        # This demonstrates that ONLY top-level / root upperRoman's are
+        # converted
+        'list_to_header',
+    )
+
+DocXFixtureTestCase.generate()

--- a/tests/export/test_docx.py
+++ b/tests/export/test_docx.py
@@ -29,13 +29,9 @@ class ConvertDocxToHtmlTestCase(DocXFixtureTestCaseFactory):
         'has_missing_image',
         'justification',
         'list_in_table',
-        # In the expected HTML output for "list_to_header", the list element
-        # GGG is expected to be "upperRoman". This is showing that only top
-        # level upperRomans are converted.
         'external_image',
         'export_from_googledocs',
         'has_missing_image',
-        'list_to_header',
         'lists_with_styles',
         'missing_numbering',
         'missing_style',

--- a/tests/export/test_xml.py
+++ b/tests/export/test_xml.py
@@ -844,62 +844,6 @@ class SDTTestCase(TranslationTestCase):
         return xml
 
 
-class RomanNumeralToHeadingTestCase(TranslationTestCase):
-    convert_root_level_upper_roman = True
-    numbering_dict = {
-        '1': {
-            '0': 'upperRoman',
-            '1': 'decimal',
-            '2': 'upperRoman',
-        },
-        '2': {
-            '0': 'upperRoman',
-            '1': 'decimal',
-            '2': 'upperRoman',
-        },
-        '3': {
-            '0': 'upperRoman',
-            '1': 'decimal',
-            '2': 'upperRoman',
-        },
-    }
-    expected_output = '''
-        <h2>AAA</h2>
-        <ol class="pydocx-list-style-type-decimal">
-            <li>BBB</li>
-        </ol>
-        <h2>CCC</h2>
-        <ol class="pydocx-list-style-type-decimal">
-            <li>DDD</li>
-        </ol>
-        <h2>EEE</h2>
-        <ol class="pydocx-list-style-type-decimal">
-            <li>FFF
-                <ol class="pydocx-list-style-type-upperRoman">
-                    <li>GGG</li>
-                </ol>
-            </li>
-        </ol>
-    '''
-
-    def get_xml(self):
-        li_text = [
-            ('AAA', 0, 1),
-            ('BBB', 1, 1),
-            ('CCC', 0, 2),
-            ('DDD', 1, 2),
-            ('EEE', 0, 3),
-            ('FFF', 1, 3),
-            ('GGG', 2, 3),
-        ]
-        body = b''
-        for text, ilvl, numId in li_text:
-            body += DXB.li(text=text, ilvl=ilvl, numId=numId)
-
-        xml = DXB.xml(body)
-        return xml
-
-
 class SuperAndSubScripts(TranslationTestCase):
     expected_output = '''
         <p>AAA<sup>BBB</sup></p>

--- a/tests/openxml/packaging/test_word_processing_document.py
+++ b/tests/openxml/packaging/test_word_processing_document.py
@@ -68,9 +68,10 @@ class WordprocessingDocumentTestCase(unittest.TestCase):
             '/word/fontTable.xml',
         )
 
-    def test_nonexistent_part(self):
+    def test_nonexistent_numbering_definitions_part(self):
         part = self.document.main_document_part.numbering_definitions_part
-        self.assertEqual(part, None)
+        self.assertNotEqual(part, None)
+        self.assertEqual(part.root_element, None)
 
     def test_image_parts(self):
         image_document = WordprocessingDocument(

--- a/tests/openxml/wordprocessing/test_abstract_num.py
+++ b/tests/openxml/wordprocessing/test_abstract_num.py
@@ -51,3 +51,28 @@ class AbstractNumTestCase(TestCase):
         for obj, (expected_class, level_id) in zip(num.levels, expected):
             assert isinstance(obj, expected_class), obj
             self.assertEqual(obj.level_id, level_id)
+
+    def test_get_level_for_level_that_does_not_exist_returns_None(self):
+        xml = b'''
+            <abstractNum abstractNumId="100">
+                <name val="foo" />
+                <lvl ilvl="1" />
+                <lvl ilvl="2" />
+                <lvl ilvl="3" />
+            </abstractNum>
+        '''
+        num = self._load_from_xml(xml)
+        self.assertEqual(num.get_level('4'), None)
+
+    def test_get_level_for_level_returns_the_level(self):
+        xml = b'''
+            <abstractNum abstractNumId="100">
+                <name val="foo" />
+                <lvl ilvl="1" />
+                <lvl ilvl="2" />
+                <lvl ilvl="3" />
+            </abstractNum>
+        '''
+        num = self._load_from_xml(xml)
+        level = num.get_level('3')
+        self.assertEqual(level.level_id, '3')

--- a/tests/openxml/wordprocessing/test_numbering.py
+++ b/tests/openxml/wordprocessing/test_numbering.py
@@ -15,13 +15,19 @@ from pydocx.openxml.wordprocessing import (
 from pydocx.util.xml import parse_xml_from_string
 
 
-class NumberingTestCase(TestCase):
+class NumberingBaseTestCase(TestCase):
+    def _load_from_xml(self, xml):
+        root = parse_xml_from_string(xml)
+        return Numbering.load(root)
+
+
+class NumberingTestCase(NumberingBaseTestCase):
     def _load_from_xml(self, xml):
         root = parse_xml_from_string(xml)
         return Numbering.load(root)
 
     def test_numbering_elements_includes_abstractNum_and_num_ordered(self):
-        xml = b'''
+        xml = '''
             <numbering>
                 <abstractNum abstractNumId="1">
                     <name val="foo"/>
@@ -38,3 +44,46 @@ class NumberingTestCase(TestCase):
         ]
         for obj, expected_class in zip(numbering.elements, expected_classes):
             assert isinstance(obj, expected_class), obj
+
+
+class NumberingGetNumberingDefinitionTestCase(NumberingBaseTestCase):
+    def test_returns_None_with_invalid_num_id(self):
+        xml = '''
+            <numbering>
+                <abstractNum abstractNumId="1">
+                    <name val="foo"/>
+                </abstractNum>
+            </numbering>
+        '''
+        numbering = self._load_from_xml(xml)
+        self.assertEqual(numbering.get_numbering_definition('1'), None)
+
+    def test_returns_None_when_abstract_num_does_not_exist(self):
+        xml = '''
+            <numbering>
+                <abstractNum abstractNumId="2">
+                    <name val="foo"/>
+                </abstractNum>
+                <num numId="1">
+                    <abstractNumId val="1" />
+                </num>
+            </numbering>
+        '''
+        numbering = self._load_from_xml(xml)
+        self.assertEqual(numbering.get_numbering_definition('1'), None)
+
+    def test_returns_numbering_definition_with_valid_num_id(self):
+        xml = '''
+            <numbering>
+                <abstractNum abstractNumId="1">
+                    <name val="foo"/>
+                </abstractNum>
+                <num numId="1">
+                    <abstractNumId val="1" />
+                </num>
+            </numbering>
+        '''
+        numbering = self._load_from_xml(xml)
+        num_definition = numbering.get_numbering_definition('1')
+        assert isinstance(num_definition, AbstractNum)
+        self.assertEqual(num_definition.name, 'foo')

--- a/tests/openxml/wordprocessing/test_numbering_properties.py
+++ b/tests/openxml/wordprocessing/test_numbering_properties.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+from __future__ import (
+    absolute_import,
+    print_function,
+    unicode_literals,
+)
+
+from unittest import TestCase
+
+from pydocx.openxml.wordprocessing import NumberingProperties
+from pydocx.util.xml import parse_xml_from_string
+
+
+class NumberingPropertiesBaseTestCase(TestCase):
+    def _load_from_xml(self, xml):
+        root = parse_xml_from_string(xml)
+        return NumberingProperties.load(root)
+
+
+class NumberingPropertiesTestCase(NumberingPropertiesBaseTestCase):
+    def test_numId_child_mapped_to_num_id_attribute(self):
+        xml = '''
+            <numPr>
+                <numId val="100"/>
+                <ilvl val="200"/>
+            </numPr>
+        '''
+        num = self._load_from_xml(xml)
+        self.assertEqual(num.num_id, "100")
+
+    def test_ilvl_child_mapped_to_level_id_attribute(self):
+        xml = '''
+            <numPr>
+                <numId val="100"/>
+                <ilvl val="200"/>
+            </numPr>
+        '''
+        num = self._load_from_xml(xml)
+        self.assertEqual(num.level_id, "200")
+
+
+class NumberingPropertiesIsRootLevelTestCase(NumberingPropertiesBaseTestCase):
+    def test_false_when_num_id_is_None(self):
+        xml = '''
+            <numPr>
+                <ilvl val="0"/>
+            </numPr>
+        '''
+        num = self._load_from_xml(xml)
+        assert not num.is_root_level()
+
+    def test_false_when_level_id_is_None(self):
+        xml = '''
+            <numPr>
+                <numId val="100"/>
+            </numPr>
+        '''
+        num = self._load_from_xml(xml)
+        assert not num.is_root_level()
+
+    def test_false_when_both_num_id_and_level_id_are_None(self):
+        xml = '''
+            <numPr>
+            </numPr>
+        '''
+        num = self._load_from_xml(xml)
+        assert not num.is_root_level()
+
+    def test_false_when_level_id_is_not_root(self):
+        xml = '''
+            <numPr>
+                <numId val="100"/>
+                <ilvl val="200"/>
+            </numPr>
+        '''
+        num = self._load_from_xml(xml)
+        assert not num.is_root_level()
+
+    def test_true_when_level_id_is_root(self):
+        xml = '''
+            <numPr>
+                <numId val="100"/>
+                <ilvl val="{root}"/>
+            </numPr>
+        '''.format(root=NumberingProperties.ROOT_LEVEL_ID)
+        num = self._load_from_xml(xml)
+        assert num.is_root_level()

--- a/tests/openxml/wordprocessing/test_paragraph_properties.py
+++ b/tests/openxml/wordprocessing/test_paragraph_properties.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+from __future__ import (
+    absolute_import,
+    print_function,
+    unicode_literals,
+)
+
+from unittest import TestCase
+
+from pydocx.openxml.wordprocessing import NumberingProperties, ParagraphProperties  # noqa
+from pydocx.util.xml import parse_xml_from_string
+
+
+class ParagraphPropertiesTestCase(TestCase):
+    def _load_from_xml(self, xml):
+        root = parse_xml_from_string(xml)
+        return ParagraphProperties.load(root)
+
+    def test_pStyle_child_mapped_to_parent_style_attribute(self):
+        xml = '''
+            <pPr>
+                <pStyle val="foostyle" />
+            </pPr>
+        '''
+        properties = self._load_from_xml(xml)
+        self.assertEqual(properties.parent_style, "foostyle")

--- a/tests/openxml/wordprocessing/test_paragraph_properties.py
+++ b/tests/openxml/wordprocessing/test_paragraph_properties.py
@@ -24,3 +24,12 @@ class ParagraphPropertiesTestCase(TestCase):
         '''
         properties = self._load_from_xml(xml)
         self.assertEqual(properties.parent_style, "foostyle")
+
+    def test_numPr_child_mapped_to_numbering_properties_attribute(self):
+        xml = '''
+            <pPr>
+                <numPr />
+            </pPr>
+        '''
+        properties = self._load_from_xml(xml)
+        assert isinstance(properties.numbering_properties, NumberingProperties)


### PR DESCRIPTION
The base PyDocX exporter accepts an option `convert_root_level_upper_roman` which, if `True`, will convert root level lists that are formatted to "upperRoman" to a heading of level 2. 

* Decouple this logic from the pre-processor / exporter, and implement it in an optional mixin
* Remote the `convert_root_level_upper_roman` option

Depends on #135 