### PR TITLE
Implement table-parent detection directly in parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@
   option has been replaced
   with an optional mixin
   ``pydocx.export.mixins.ConvertRootUpperRomanListToHeadingMixin``.
+- Preprocessor no longer manages table membership.
+  Instead, that is handled in the base iterative parser.
 
 **0.6.0**
 

--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -278,6 +278,9 @@ class PyDocXExporter(MultiMemoizeMixin):
     def parse(self, el):
         return self.parser.parse(el)
 
+    def _has_direct_parent(self, stack, tag_name):
+        return stack and stack[-1]['element'].tag == tag_name
+
     def _get_page_width(self, root_element):
         pgSzEl = root_element.find('./body/sectPr/pgSz')
         if pgSzEl is not None:
@@ -336,7 +339,7 @@ class PyDocXExporter(MultiMemoizeMixin):
         self.list_depth += 1
         parsed = self._parse_list(el, text, stack)
         self.list_depth -= 1
-        if self.pre_processor.is_in_table(el):
+        if self._has_direct_parent(stack, 'tc'):
             return self.parse_table_cell_contents(el, parsed, stack)
         return parsed
 
@@ -499,7 +502,7 @@ class PyDocXExporter(MultiMemoizeMixin):
             return self.parse_list(el, text, stack)
         if self.pre_processor.is_list_item(el):
             return self.parse_list_item(el, text, stack)
-        if self.pre_processor.is_in_table(el):
+        if self._has_direct_parent(stack, 'tc'):
             return self.parse_table_cell_contents(el, text, stack)
         parsed = text
         # No p tags in li tags

--- a/pydocx/openxml/packaging/style_definitions_part.py
+++ b/pydocx/openxml/packaging/style_definitions_part.py
@@ -136,7 +136,7 @@ class StyleDefinitionsPart(OpenXmlPart):
         properties = {}
 
         for item in stack:
-            element = item['element']
+            element = item.element
             properties.update(self._resolve_properties_for_element(element))
 
         properties.update(self._resolve_properties_for_element(el))

--- a/pydocx/util/preprocessor.py
+++ b/pydocx/util/preprocessor.py
@@ -66,7 +66,6 @@ class PydocxPreProcessor(MultiMemoizeMixin):
         if self.numbering_root is not None:
             self._set_list_attributes(root)
         self._set_table_attributes(root)
-        self._set_is_in_table(root)
 
         body = root.find('./body')
         self._set_next(body)
@@ -101,9 +100,6 @@ class PydocxPreProcessor(MultiMemoizeMixin):
         if not self.is_list_item(el):
             return None
         return self.meta_data[el].get('ilvl')
-
-    def is_in_table(self, el):
-        return self.meta_data[el].get('is_in_table')
 
     def row_index(self, el):
         return self.meta_data[el].get('row_index')
@@ -241,12 +237,6 @@ class PydocxPreProcessor(MultiMemoizeMixin):
                              v_merge.attrib == {})
                     ):
                         self.meta_data[child]['vmerge_continue'] = True
-
-    def _set_is_in_table(self, el):
-        paragraph_elements = find_all(el, 'p')
-        for p in paragraph_elements:
-            if find_ancestor_with_tag(self, p, 'tc') is not None:
-                self.meta_data[p]['is_in_table'] = True
 
     def _set_next(self, body):
         def _get_children_with_content(el):


### PR DESCRIPTION
Currently, the preprocessor tracks table membership. This isn't necessary anymore. 