### PR TITLE
"cString" import doesn't exist: it's a typo

### DIFF
--- a/pydocx/packaging.py
+++ b/pydocx/packaging.py
@@ -7,11 +7,7 @@ from __future__ import (
 import posixpath
 import zipfile
 from collections import defaultdict
-try:
-    from cString import StringIO
-    BytesIO = StringIO
-except ImportError:
-    from io import BytesIO
+from io import BytesIO
 
 from pydocx.exceptions import MalformedDocxException
 from pydocx.util.xml import (

--- a/pydocx/test/utils.py
+++ b/pydocx/test/utils.py
@@ -7,13 +7,8 @@ from __future__ import (
 import posixpath
 import re
 import os.path
+from io import BytesIO
 from xml.dom import minidom
-
-try:
-    from cString import StringIO
-    BytesIO = StringIO
-except ImportError:
-    from io import BytesIO
 
 from pydocx.packaging import PackageRelationship, ZipPackagePart
 from pydocx.export.html import PyDocXHTMLExporter

--- a/pydocx/util/zip.py
+++ b/pydocx/util/zip.py
@@ -6,11 +6,7 @@ from __future__ import (
 
 import zipfile
 from contextlib import contextmanager
-
-try:
-    from cString import StringIO as BytesIO
-except ImportError:
-    from io import BytesIO
+from io import BytesIO
 
 from pydocx.exceptions import MalformedDocxException
 


### PR DESCRIPTION
In several locations, we try to import from `cString` (instead of `cStringIO`). This exception is ignored because it's inside a try...except for the purpose of supporting python2/python3.