### PR TITLE
Fix FutureWarning with testing element existence

### DIFF
--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -315,7 +315,7 @@ class PyDocXExporter(MultiMemoizeMixin):
             return footnotes
         if not main_document_part.footnotes_part:
             return footnotes
-        if not main_document_part.footnotes_part.root_element:
+        if main_document_part.footnotes_part.root_element is None:
             return footnotes
         self.current_part = main_document_part.footnotes_part
         for element in main_document_part.footnotes_part.root_element:

--- a/pydocx/models.py
+++ b/pydocx/models.py
@@ -245,7 +245,7 @@ class XmlModel(object):
             for tag_name in field.name_to_type_map.keys():
                 collection_member_to_collections[tag_name].append(field_name)
 
-        if element:
+        if element is not None:
             # Process each child
             for child in element:
                 tag = child.tag


### PR DESCRIPTION
```
pydocx/pydocx/models.py:248: FutureWarning: The behavior of this method will change in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
  if element:
pydocx/pydocx/export/base.py:318: FutureWarning: The behavior of this method will change in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
  if not main_document_part.footnotes_part.root_element:
```