### PR TITLE
Handle numFmt = none

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+**dev**
+
+- Paragraphs that have numbering definitions with a level number format of None
+  are no longer considered list items.
+
 **0.8.1**
 
 - Headings in lists no longer break numbering. By default, in the HTML

--- a/pydocx/export/numbering_span.py
+++ b/pydocx/export/numbering_span.py
@@ -201,7 +201,10 @@ class BaseNumberingSpanBuilder(object):
 
     @memoized
     def get_numbering_level(self, paragraph):
-        return paragraph.get_numbering_level()
+        level = paragraph.get_numbering_level()
+        if level and level.format_is_none():
+            return None
+        return level
 
     def include_candidate_items_in_current_item(self, new_item_index):
         '''
@@ -554,6 +557,9 @@ class FakeNumberingDetection(object):
 
     def detect_faked_list(self, paragraph):
         level = paragraph.get_numbering_level()
+        if level and level.format_is_none():
+            return None
+
         left_position = self.get_left_position_for_paragraph(paragraph)
 
         if self.current_span:

--- a/pydocx/export/numbering_span.py
+++ b/pydocx/export/numbering_span.py
@@ -558,7 +558,7 @@ class FakeNumberingDetection(object):
     def detect_faked_list(self, paragraph):
         level = paragraph.get_numbering_level()
         if level and level.format_is_none():
-            return None
+            level = None
 
         left_position = self.get_left_position_for_paragraph(paragraph)
 

--- a/pydocx/openxml/wordprocessing/level.py
+++ b/pydocx/openxml/wordprocessing/level.py
@@ -23,3 +23,8 @@ class Level(XmlModel):
 
     def is_bullet_format(self):
         return self.num_format == 'bullet'
+
+    def format_is_none(self):
+        if not self.num_format:
+            return True
+        return self.num_format.lower() == 'none'

--- a/tests/export/html/test_numbering.py
+++ b/tests/export/html/test_numbering.py
@@ -1687,6 +1687,46 @@ class FakedNumberingTestCase(NumberingTestBase, DocumentGeneratorTestCase):
 
         self.assert_main_document_xml_generates_html(document_xml, expected_html)
 
+    def test_faked_list_with_list_level_numfmt_None_still_detected(self):
+        document_xml = '''
+            {aaa}
+            {bbb}
+        '''.format(
+            aaa=self.simple_list_item.format(
+                content='1. AAA',
+                num_id=1,
+                ilvl=0,
+            ),
+            bbb=self.simple_list_item.format(
+                content='2. BBB',
+                num_id=1,
+                ilvl=0,
+            ),
+        )
+
+        numbering_xml = '''
+            <num numId="1">
+                <abstractNumId val="1"/>
+            </num>
+            <abstractNum abstractNumId="1">
+                <lvl ilvl="0">
+                    <numFmt val="none"/>
+                </lvl>
+            </abstractNum>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(NumberingDefinitionsPart, numbering_xml)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <ol class="pydocx-list-style-type-decimal">
+                <li>AAA</li>
+                <li>BBB</li>
+            </ol>
+        '''
+        self.assert_document_generates_html(document, expected_html)
+
 
 class FakedNumberingPatternBase(object):
     def assert_html_using_pattern(self, pattern):

--- a/tests/export/html/test_numbering.py
+++ b/tests/export/html/test_numbering.py
@@ -1056,6 +1056,63 @@ class NumberingTestCase(NumberingTestBase, DocumentGeneratorTestCase):
         '''
         self.assert_document_generates_html(document, expected_html)
 
+    def test_root_level_numfmt_None_with_sublist(self):
+        document_xml = '''
+            {aaa}
+            {bbb}
+            {ccc}
+            {ddd}
+        '''.format(
+            aaa=self.simple_list_item.format(
+                content='AAA',
+                num_id=1,
+                ilvl=0,
+            ),
+            bbb=self.simple_list_item.format(
+                content='BBB',
+                num_id=1,
+                ilvl=1,
+            ),
+            ccc=self.simple_list_item.format(
+                content='CCC',
+                num_id=1,
+                ilvl=1,
+            ),
+            ddd=self.simple_list_item.format(
+                content='DDD',
+                num_id=1,
+                ilvl=0,
+            ),
+        )
+
+        numbering_xml = '''
+            <num numId="1">
+                <abstractNumId val="1"/>
+            </num>
+            <abstractNum abstractNumId="1">
+                <lvl ilvl="0">
+                    <numFmt val="none"/>
+                </lvl>
+                <lvl ilvl="1">
+                    <numFmt val="decimal"/>
+                </lvl>
+            </abstractNum>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(NumberingDefinitionsPart, numbering_xml)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <p>AAA</p>
+            <ol class="pydocx-list-style-type-decimal">
+                <li>BBB</li>
+                <li>CCC</li>
+            </ol>
+            <p>DDD</p>
+        '''
+        self.assert_document_generates_html(document, expected_html)
+
 
 class FakedNumberingManyItemsTestCase(NumberingTestBase, DocumentGeneratorTestCase):
     def assert_html(self, list_type, digit_generator):

--- a/tests/export/html/test_numbering.py
+++ b/tests/export/html/test_numbering.py
@@ -957,6 +957,44 @@ class NumberingTestCase(NumberingTestBase, DocumentGeneratorTestCase):
         '''
         self.assert_document_generates_html(document, expected_html)
 
+    def test_numfmt_None_causes_list_to_be_ignored(self):
+        document_xml = '''
+            {aaa}
+            {bbb}
+        '''.format(
+            aaa=self.simple_list_item.format(
+                content='AAA',
+                num_id=1,
+                ilvl=0,
+            ),
+            bbb=self.simple_list_item.format(
+                content='BBB',
+                num_id=1,
+                ilvl=0,
+            ),
+        )
+
+        numbering_xml = '''
+            <num numId="1">
+                <abstractNumId val="1"/>
+            </num>
+            <abstractNum abstractNumId="1">
+                <lvl ilvl="0">
+                    <numFmt val="none"/>
+                </lvl>
+            </abstractNum>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(NumberingDefinitionsPart, numbering_xml)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <p>AAA</p>
+            <p>BBB</p>
+        '''
+        self.assert_document_generates_html(document, expected_html)
+
 
 class FakedNumberingManyItemsTestCase(NumberingTestBase, DocumentGeneratorTestCase):
     def assert_html(self, list_type, digit_generator):

--- a/tests/export/html/test_numbering.py
+++ b/tests/export/html/test_numbering.py
@@ -995,6 +995,67 @@ class NumberingTestCase(NumberingTestBase, DocumentGeneratorTestCase):
         '''
         self.assert_document_generates_html(document, expected_html)
 
+    def test_numfmt_None_causes_sub_list_to_be_ignored(self):
+        document_xml = '''
+            {aaa}
+            {bbb}
+            {ccc}
+            {ddd}
+        '''.format(
+            aaa=self.simple_list_item.format(
+                content='AAA',
+                num_id=1,
+                ilvl=0,
+            ),
+            bbb=self.simple_list_item.format(
+                content='BBB',
+                num_id=1,
+                ilvl=1,
+            ),
+            ccc=self.simple_list_item.format(
+                content='CCC',
+                num_id=1,
+                ilvl=1,
+            ),
+            ddd=self.simple_list_item.format(
+                content='DDD',
+                num_id=1,
+                ilvl=0,
+            ),
+        )
+
+        numbering_xml = '''
+            <num numId="1">
+                <abstractNumId val="1"/>
+            </num>
+            <abstractNum abstractNumId="1">
+                <lvl ilvl="0">
+                    <numFmt val="decimal"/>
+                </lvl>
+                <lvl ilvl="1">
+                    <numFmt val="none"/>
+                </lvl>
+            </abstractNum>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(NumberingDefinitionsPart, numbering_xml)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <ol class="pydocx-list-style-type-decimal">
+                <li>
+                    AAA
+                    <br/>
+                    BBB
+                    <br/>
+                    CCC
+                </li>
+                <li>DDD</li>
+            </ol>
+        '''
+        self.assert_document_generates_html(document, expected_html)
+
 
 class FakedNumberingManyItemsTestCase(NumberingTestBase, DocumentGeneratorTestCase):
     def assert_html(self, list_type, digit_generator):

--- a/tests/export/html/test_numbering.py
+++ b/tests/export/html/test_numbering.py
@@ -1046,9 +1046,9 @@ class NumberingTestCase(NumberingTestBase, DocumentGeneratorTestCase):
             <ol class="pydocx-list-style-type-decimal">
                 <li>
                     AAA
-                    <br/>
+                    <br />
                     BBB
-                    <br/>
+                    <br />
                     CCC
                 </li>
                 <li>DDD</li>

--- a/tests/openxml/wordprocessing/test_level.py
+++ b/tests/openxml/wordprocessing/test_level.py
@@ -21,63 +21,37 @@ class LevelTestCase(TestCase):
         return Level.load(root)
 
     def test_ilvl_mapped_to_level_id_attribute(self):
-        xml = b'''
-            <lvl ilvl="100">
-            </lvl>
-        '''
+        xml = '<lvl ilvl="100"></lvl>'
         level = self._load_from_xml(xml)
-        self.assertEqual(level.level_id, "100")
+        self.assertEqual(level.level_id, '100')
 
     def test_starting_position_attribute(self):
-        xml = b'''
-            <lvl>
-                <start val="50" />
-            </lvl>
-        '''
+        xml = '<lvl><start val="50" /></lvl>'
         level = self._load_from_xml(xml)
-        self.assertEqual(level.start, "50")
+        self.assertEqual(level.start, '50')
 
     def test_num_format_attribute(self):
-        xml = b'''
-            <lvl>
-                <numFmt val="decimal" />
-            </lvl>
-        '''
+        xml = '<lvl><numFmt val="decimal" /></lvl>'
         level = self._load_from_xml(xml)
-        self.assertEqual(level.num_format, "decimal")
+        self.assertEqual(level.num_format, 'decimal')
 
     def test_restart_attribute(self):
-        xml = b'''
-            <lvl>
-                <lvlRestart val="1" />
-            </lvl>
-        '''
+        xml = '<lvl><lvlRestart val="1" /></lvl>'
         level = self._load_from_xml(xml)
-        self.assertEqual(level.restart, "1")
+        self.assertEqual(level.restart, '1')
 
     def test_associated_paragraph_style_attribute(self):
-        xml = b'''
-            <lvl>
-                <pStyle val="normal" />
-            </lvl>
-        '''
+        xml = '<lvl><pStyle val="normal" /></lvl>'
         level = self._load_from_xml(xml)
-        self.assertEqual(level.paragraph_style, "normal")
+        self.assertEqual(level.paragraph_style, 'normal')
 
     def test_run_properties_child(self):
-        xml = b'''
-            <lvl>
-                <rPr />
-            </lvl>
-        '''
+        xml = '<lvl><rPr /></lvl>'
         level = self._load_from_xml(xml)
-        assert isinstance(level.run_properties, RunProperties), level.run_properties  # noqa
+        assert isinstance(level.run_properties, RunProperties), level.run_properties
 
     def test_paragraph_properties_child(self):
-        xml = b'''
-            <lvl>
-                <pPr />
-            </lvl>
-        '''
+        xml = '<lvl><pPr /></lvl>'
         level = self._load_from_xml(xml)
-        assert isinstance(level.paragraph_properties, ParagraphProperties), level.paragraph_properties  # noqa
+        properties = level.paragraph_properties
+        assert isinstance(properties, ParagraphProperties), properties

--- a/tests/openxml/wordprocessing/test_level.py
+++ b/tests/openxml/wordprocessing/test_level.py
@@ -55,3 +55,18 @@ class LevelTestCase(TestCase):
         level = self._load_from_xml(xml)
         properties = level.paragraph_properties
         assert isinstance(properties, ParagraphProperties), properties
+
+    def test_format_is_none_when_not_set(self):
+        xml = '<lvl></lvl>'
+        level = self._load_from_xml(xml)
+        assert level.format_is_none()
+
+    def test_format_is_none_when_set_to_none(self):
+        xml = '<lvl><numFmt val="none" /></lvl>'
+        level = self._load_from_xml(xml)
+        assert level.format_is_none()
+
+    def test_format_is_none_when_set_to_none_case_insensitive(self):
+        xml = '<lvl><numFmt val="NoNe" /></lvl>'
+        level = self._load_from_xml(xml)
+        assert level.format_is_none()


### PR DESCRIPTION
It's possible for `numFmt` to be `none`. In this case, don't display any list styling.