### PR TITLE
Font size can be a float

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**dev**
+
+- Float font sizes are now handled properly
+
 **0.8.1**
 
 - Headings in lists no longer break numbering. By default, in the HTML

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 **dev**
 
-- Float font sizes are now handled properly
+- Decimal font sizes are now handled properly
 
 **0.8.1**
 

--- a/pydocx/openxml/wordprocessing/run_properties.py
+++ b/pydocx/openxml/wordprocessing/run_properties.py
@@ -36,7 +36,11 @@ class RunProperties(XmlModel):
     def size(self):
         if self.sz is None:
             return
-        return int(self.sz)
+        try:
+            size = float(self.sz)
+        except ValueError:
+            size = None
+        return size
 
     def is_superscript(self):
         return self.vertical_align == 'superscript'

--- a/tests/openxml/wordprocessing/test_run_properties.py
+++ b/tests/openxml/wordprocessing/test_run_properties.py
@@ -71,3 +71,13 @@ class RunPropertiesTestCase(TestCase):
         xml = '<rPr><position val="10"/></rPr>'
         properties = self._load_styles_from_xml(xml)
         self.assertEqual(properties.position, int(properties.pos))
+
+    def test_size_property_can_be_a_decimal(self):
+        xml = '<rPr><sz val="10.1234"/></rPr>'
+        properties = self._load_styles_from_xml(xml)
+        self.assertEqual(properties.size, 10.1234)
+
+    def test_size_property_has_garbage_returns_0(self):
+        xml = '<rPr><sz val="abcdef"/></rPr>'
+        properties = self._load_styles_from_xml(xml)
+        self.assertEqual(properties.size, None)


### PR DESCRIPTION
```
  File "/home/policystat/env/lib/python2.6/site-packages/pydocx/export/base.py", line 101, in export_node
    for result in caller(node):
  File "/opt/pstat/versions/current/pstat/core/import_translation/translation.py", line 236, in export_run
    results = super(PstatDocx2Html, self).export_run(run)
  File "/home/policystat/env/lib/python2.6/site-packages/pydocx/export/base.py", line 209, in export_run
    results = self.export_run_apply_properties(run, results)
  File "/home/policystat/env/lib/python2.6/site-packages/pydocx/export/base.py", line 234, in export_run_apply_properties
    for func in styles_to_apply:
  File "/home/policystat/env/lib/python2.6/site-packages/pydocx/export/mixins/faked_superscript_and_subscript.py", line 40, in get_run_styles_to_apply
    if could_be_a_faked_sub_or_superscript():
  File "/home/policystat/env/lib/python2.6/site-packages/pydocx/export/mixins/faked_superscript_and_subscript.py", line 22, in could_be_a_faked_sub_or_superscript
    if effective_properties.size is None:
  File "/home/policystat/env/lib/python2.6/site-packages/pydocx/openxml/wordprocessing/run_properties.py", line 39, in size
    return int(self.sz)
ValueError: invalid literal for int() with base 10: '11.519531'
```