### PR TITLE
Headings should preserve certain styles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**dev**
+
+- Headings now preserve italic, webHidden and vanish styles
+
 **0.8.3**
 
 - Decimal font sizes are now handled properly

--- a/pydocx/export/html.py
+++ b/pydocx/export/html.py
@@ -515,8 +515,7 @@ class PyDocXHTMLExporter(PyDocXExporter):
 
         tag = None
         if start_new_tag:
-            parent_tables = table_cell.nearest_ancestors(wordprocessing.Table)
-            parent_table = get_first_from_sequence(parent_tables)
+            parent_table = table_cell.get_first_ancestor(wordprocessing.Table)
             rowspan_counts = self.table_cell_rowspan_tracking[parent_table]
             rowspan = rowspan_counts.get(table_cell, 1)
             attrs = {}
@@ -624,10 +623,9 @@ class PyDocXHTMLExporter(PyDocXExporter):
             yield result
 
     def export_footnote_reference_mark(self, footnote_reference_mark):
-        footnote_parents = footnote_reference_mark.nearest_ancestors(
+        footnote_parent = footnote_reference_mark.get_first_ancestor(
             wordprocessing.Footnote,
         )
-        footnote_parent = get_first_from_sequence(footnote_parents)
         if not footnote_parent:
             return
 

--- a/pydocx/export/html.py
+++ b/pydocx/export/html.py
@@ -346,6 +346,8 @@ class PyDocXHTMLExporter(PyDocXExporter):
     def get_run_styles_to_apply_for_heading(self, run):
         allowed_handlers = set([
             self.export_run_property_italic,
+            self.export_run_property_hidden,
+            self.export_run_property_vanish,
         ])
 
         handlers = super(PyDocXHTMLExporter, self).get_run_styles_to_apply(run)

--- a/pydocx/export/html.py
+++ b/pydocx/export/html.py
@@ -335,14 +335,23 @@ class PyDocXHTMLExporter(PyDocXExporter):
         return results
 
     def get_run_styles_to_apply(self, run):
-        parent_paragraphs = run.nearest_ancestors(wordprocessing.Paragraph)
-        parent_paragraph = get_first_from_sequence(parent_paragraphs)
+        parent_paragraph = run.get_first_ancestor(wordprocessing.Paragraph)
         if parent_paragraph and parent_paragraph.heading_style:
-            # If the parent paragraph is a heading, return an empty generator
-            return
-        results = super(PyDocXHTMLExporter, self).get_run_styles_to_apply(run)
+            results = self.get_run_styles_to_apply_for_heading(run)
+        else:
+            results = super(PyDocXHTMLExporter, self).get_run_styles_to_apply(run)
         for result in results:
             yield result
+
+    def get_run_styles_to_apply_for_heading(self, run):
+        allowed_handlers = set([
+            self.export_run_property_italic,
+        ])
+
+        handlers = super(PyDocXHTMLExporter, self).get_run_styles_to_apply(run)
+        for handler in handlers:
+            if handler in allowed_handlers:
+                yield handler
 
     def export_run_property_bold(self, run, results):
         tag = HtmlTag('strong')

--- a/pydocx/models.py
+++ b/pydocx/models.py
@@ -201,9 +201,12 @@ class XmlModel(object):
             node = node.parent
 
     def has_ancestor(self, ancestor_type):
+        first = self.get_first_ancestor(ancestor_type)
+        return first is not None
+
+    def get_first_ancestor(self, ancestor_type):
         for ancestor in self.nearest_ancestors(ancestor_type):
-            return True
-        return False
+            return ancestor
 
     def __repr__(self):
         return '{klass}({kwargs})'.format(

--- a/pydocx/openxml/wordprocessing/paragraph.py
+++ b/pydocx/openxml/wordprocessing/paragraph.py
@@ -45,13 +45,7 @@ class Paragraph(XmlModel):
 
     def has_structured_document_parent(self):
         from pydocx.openxml.wordprocessing import SdtBlock
-        structured_parent = self.nearest_ancestors(SdtBlock)
-        try:
-            next(structured_parent)
-            return True
-        except StopIteration:
-            pass
-        return False
+        return self.has_ancestor(SdtBlock)
 
     def get_style_chain_stack(self):
         if not self.properties:

--- a/pydocx/openxml/wordprocessing/run.py
+++ b/pydocx/openxml/wordprocessing/run.py
@@ -5,7 +5,6 @@ from __future__ import (
     unicode_literals,
 )
 
-from itertools import islice
 
 from pydocx.models import XmlModel, XmlCollection, XmlChild
 from pydocx.openxml.wordprocessing.run_properties import RunProperties
@@ -61,11 +60,8 @@ class Run(XmlModel):
 
         inherited_properties = {}
 
-        nearest_paragraphs = self.nearest_ancestors(Paragraph)
-        # TODO use get_first_from_sequence utility?
-        parent_paragraph = list(islice(nearest_paragraphs, 0, 1))
+        parent_paragraph = self.get_first_ancestor(Paragraph)
         if parent_paragraph:
-            parent_paragraph = parent_paragraph[0]
             style_stack = parent_paragraph.get_style_chain_stack()
             for style in reversed(list(style_stack)):
                 if style.run_properties:

--- a/tests/export/html/test_heading.py
+++ b/tests/export/html/test_heading.py
@@ -69,6 +69,48 @@ class HeadingStylesTestCase(DocumentGeneratorTestCase):
         '''
         self.assert_document_generates_html(document, expected_html)
 
+    def test_vanished_is_preserved(self):
+        style_xml = '''
+            <style styleId="heading1" type="paragraph">
+              <name val="Heading 1"/>
+              <rPr>
+                <vanish val="on"/>
+              </rPr>
+            </style>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, self.document_xml)
+
+        expected_html = '''
+            <h1>
+                <span class="pydocx-hidden">aaa</span>
+            </h1>
+        '''
+        self.assert_document_generates_html(document, expected_html)
+
+    def test_hidden_is_preserved(self):
+        style_xml = '''
+            <style styleId="heading1" type="paragraph">
+              <name val="Heading 1"/>
+              <rPr>
+                <webHidden val="on"/>
+              </rPr>
+            </style>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, self.document_xml)
+
+        expected_html = '''
+            <h1>
+                <span class="pydocx-hidden">aaa</span>
+            </h1>
+        '''
+        self.assert_document_generates_html(document, expected_html)
+
 
 class HeadingTestCase(DocumentGeneratorTestCase):
     def test_each_heading_level(self):

--- a/tests/export/html/test_heading.py
+++ b/tests/export/html/test_heading.py
@@ -15,10 +15,19 @@ from pydocx.test import DocumentGeneratorTestCase
 from pydocx.test.utils import WordprocessingDocumentFactory
 
 
-class HeadingTestCase(DocumentGeneratorTestCase):
-    def test_character_stylings_are_ignored(self):
-        # Even though the heading1 style has bold enabled, it's being ignored
-        # because the style is for a header
+class HeadingStylesTestCase(DocumentGeneratorTestCase):
+    document_xml = '''
+        <p>
+          <pPr>
+            <pStyle val="heading1"/>
+          </pPr>
+          <r>
+            <t>aaa</t>
+          </r>
+        </p>
+    '''
+
+    def test_bold_styling_ignored(self):
         style_xml = '''
             <style styleId="heading1" type="paragraph">
               <name val="Heading 1"/>
@@ -28,26 +37,17 @@ class HeadingTestCase(DocumentGeneratorTestCase):
             </style>
         '''
 
-        document_xml = '''
-            <p>
-              <pPr>
-                <pStyle val="heading1"/>
-              </pPr>
-              <r>
-                <t>aaa</t>
-              </r>
-            </p>
-        '''
-
         document = WordprocessingDocumentFactory()
         document.add(StyleDefinitionsPart, style_xml)
-        document.add(MainDocumentPart, document_xml)
+        document.add(MainDocumentPart, self.document_xml)
 
         expected_html = '''
             <h1>aaa</h1>
         '''
         self.assert_document_generates_html(document, expected_html)
 
+
+class HeadingTestCase(DocumentGeneratorTestCase):
     def test_each_heading_level(self):
         style_template = '''
             <style styleId="heading%s" type="paragraph">

--- a/tests/export/html/test_heading.py
+++ b/tests/export/html/test_heading.py
@@ -27,7 +27,7 @@ class HeadingStylesTestCase(DocumentGeneratorTestCase):
         </p>
     '''
 
-    def test_bold_styling_ignored(self):
+    def test_bold_ignored(self):
         style_xml = '''
             <style styleId="heading1" type="paragraph">
               <name val="Heading 1"/>

--- a/tests/export/html/test_heading.py
+++ b/tests/export/html/test_heading.py
@@ -46,6 +46,25 @@ class HeadingStylesTestCase(DocumentGeneratorTestCase):
         '''
         self.assert_document_generates_html(document, expected_html)
 
+    def test_italic_preserved(self):
+        style_xml = '''
+            <style styleId="heading1" type="paragraph">
+              <name val="Heading 1"/>
+              <rPr>
+                <i val="on"/>
+              </rPr>
+            </style>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, self.document_xml)
+
+        expected_html = '''
+            <h1><em>aaa</em></h1>
+        '''
+        self.assert_document_generates_html(document, expected_html)
+
 
 class HeadingTestCase(DocumentGeneratorTestCase):
     def test_each_heading_level(self):

--- a/tests/export/html/test_heading.py
+++ b/tests/export/html/test_heading.py
@@ -27,12 +27,16 @@ class HeadingStylesTestCase(DocumentGeneratorTestCase):
         </p>
     '''
 
-    def test_bold_ignored(self):
+    def test_ignored_styles(self):
         style_xml = '''
             <style styleId="heading1" type="paragraph">
               <name val="Heading 1"/>
               <rPr>
                 <b val="on"/>
+                <caps val="on"/>
+                <smallCaps val="on"/>
+                <strike val="on"/>
+                <dstrike val="on"/>
               </rPr>
             </style>
         '''


### PR DESCRIPTION
Currently, headings strip out all styling information. This prevents weird cases like `<h2><strong>Foo</strong></h2>` but it also means that headings don't have any other styles, like italics. Update headings to preserve italic. Also, headings that use vanish or hidden styles should have the vanished or hidden spans applied.