### PR TITLE
Styled whitespace is ignored

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+**dev**
+
+- Styled whitespace is no longer ignored. Previously, this would result in
+  certain configurations with words grouped together without spaces.
+
 **0.8.4**
 
 - Headings now preserve italic, webHidden and vanish styles

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -165,4 +165,4 @@ v2.0.0
 
   .. code-block:: shell-session
 
-    python setup.py sdist upload
+    make release

--- a/pydocx/export/html.py
+++ b/pydocx/export/html.py
@@ -371,62 +371,78 @@ class PyDocXHTMLExporter(PyDocXExporter):
             if handler in allowed_handlers:
                 yield handler
 
+    def export_run_property(self, tag, run, results):
+        # Any leading whitespace in the run is not styled.
+        for result in results:
+            if is_only_whitespace(result):
+                yield result
+            else:
+                # We've encountered something that isn't explicit whitespace
+                results = chain([result], results)
+                break
+        else:
+            results = None
+
+        if results:
+            for result in tag.apply(results):
+                yield result
+
     def export_run_property_bold(self, run, results):
         tag = HtmlTag('strong')
-        return tag.apply(results, allow_empty=False)
+        return self.export_run_property(tag, run, results)
 
     def export_run_property_italic(self, run, results):
         tag = HtmlTag('em')
-        return tag.apply(results, allow_empty=False)
+        return self.export_run_property(tag, run, results)
 
     def export_run_property_underline(self, run, results):
         attrs = {
             'class': 'pydocx-underline',
         }
         tag = HtmlTag('span', **attrs)
-        return tag.apply(results, allow_empty=False)
+        return self.export_run_property(tag, run, results)
 
     def export_run_property_caps(self, run, results):
         attrs = {
             'class': 'pydocx-caps',
         }
         tag = HtmlTag('span', **attrs)
-        return tag.apply(results, allow_empty=False)
+        return self.export_run_property(tag, run, results)
 
     def export_run_property_small_caps(self, run, results):
         attrs = {
             'class': 'pydocx-small-caps',
         }
         tag = HtmlTag('span', **attrs)
-        return tag.apply(results, allow_empty=False)
+        return self.export_run_property(tag, run, results)
 
     def export_run_property_dstrike(self, run, results):
         attrs = {
             'class': 'pydocx-strike',
         }
         tag = HtmlTag('span', **attrs)
-        return tag.apply(results, allow_empty=False)
+        return self.export_run_property(tag, run, results)
 
     def export_run_property_strike(self, run, results):
         attrs = {
             'class': 'pydocx-strike',
         }
         tag = HtmlTag('span', **attrs)
-        return tag.apply(results, allow_empty=False)
+        return self.export_run_property(tag, run, results)
 
     def export_run_property_vanish(self, run, results):
         attrs = {
             'class': 'pydocx-hidden',
         }
         tag = HtmlTag('span', **attrs)
-        return tag.apply(results, allow_empty=False)
+        return self.export_run_property(tag, run, results)
 
     def export_run_property_hidden(self, run, results):
         attrs = {
             'class': 'pydocx-hidden',
         }
         tag = HtmlTag('span', **attrs)
-        return tag.apply(results, allow_empty=False)
+        return self.export_run_property(tag, run, results)
 
     def export_run_property_vertical_align(self, run, results):
         if run.effective_properties.is_superscript():

--- a/tests/export/html/test_paragraph.py
+++ b/tests/export/html/test_paragraph.py
@@ -11,6 +11,50 @@ from pydocx.test.utils import WordprocessingDocumentFactory
 from pydocx.openxml.packaging import MainDocumentPart
 
 
+class NoEmptyParagraphsTestCase(DocumentGeneratorTestCase):
+    def test_no_runs_no_text(self):
+        document_xml = '<p></p>'
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = ''
+        self.assert_document_generates_html(document, expected_html)
+
+    def test_multiple_runs_with_only_whitespace(self):
+        document_xml = '''
+            <p>
+              <r>
+                <t> </t>
+              </r>
+              <r>
+                <t> </t>
+              </r>
+            </p>
+        '''
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = ''
+        self.assert_document_generates_html(document, expected_html)
+
+    def test_run_with_only_whitespace_styled(self):
+        document_xml = '''
+            <p>
+              <r>
+                <rPr>
+                  <b />
+                </rPr>
+                <t> </t>
+              </r>
+            </p>
+        '''
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = ''
+        self.assert_document_generates_html(document, expected_html)
+
+
 class ParagraphTestCase(DocumentGeneratorTestCase):
     def test_single_styled_whitespace_in_text_run_is_preserved(self):
         document_xml = '''

--- a/tests/export/html/test_paragraph.py
+++ b/tests/export/html/test_paragraph.py
@@ -12,6 +12,29 @@ from pydocx.openxml.packaging import MainDocumentPart
 
 
 class ParagraphTestCase(DocumentGeneratorTestCase):
+    def test_single_styled_whitespace_in_text_run_is_preserved(self):
+        document_xml = '''
+            <p>
+              <r>
+                <t>Foo</t>
+              </r>
+              <r>
+                <rPr>
+                    <b />
+                </rPr>
+                <t> </t>
+              </r>
+              <r>
+                <t>Bar</t>
+              </r>
+            </p>
+        '''
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '<p>Foo Bar</p>'
+        self.assert_document_generates_html(document, expected_html)
+
     def test_single_whitespace_in_text_run_is_preserved(self):
         document_xml = '''
             <p>

--- a/tests/export/html/test_paragraph.py
+++ b/tests/export/html/test_paragraph.py
@@ -64,7 +64,7 @@ class ParagraphTestCase(DocumentGeneratorTestCase):
               </r>
               <r>
                 <rPr>
-                    <b />
+                  <b />
                 </rPr>
                 <t> </t>
               </r>
@@ -77,6 +77,65 @@ class ParagraphTestCase(DocumentGeneratorTestCase):
         document.add(MainDocumentPart, document_xml)
 
         expected_html = '<p>Foo Bar</p>'
+        self.assert_document_generates_html(document, expected_html)
+
+    def test_single_multi_styled_whitespace_in_text_run_is_preserved(self):
+        document_xml = '''
+            <p>
+              <r>
+                <t>Foo</t>
+              </r>
+              <r>
+                <rPr>
+                  <b />
+                  <i />
+                  <u val="single"/>
+                  <caps />
+                  <smallCaps />
+                  <dstrike />
+                  <strike />
+                  <webHidden />
+                  <vanish />
+                </rPr>
+                <t> </t>
+              </r>
+              <r>
+                <t>Bar</t>
+              </r>
+            </p>
+        '''
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '<p>Foo Bar</p>'
+        self.assert_document_generates_html(document, expected_html)
+
+    def test_multiple_runs_with_styles(self):
+        document_xml = '''
+            <p>
+              <r>
+                <rPr>
+                  <b />
+                </rPr>
+                <t>Foo-</t>
+              </r>
+              <r>
+                <rPr>
+                  <b />
+                </rPr>
+                <t>Bar</t>
+              </r>
+            </p>
+        '''
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <p>
+            <strong>Foo-</strong>
+            <strong>Bar</strong>
+            </p>
+        '''
         self.assert_document_generates_html(document, expected_html)
 
     def test_single_whitespace_in_text_run_is_preserved(self):


### PR DESCRIPTION
Actual result: `<p>FooBar</p>`

```python
    def test_single_styled_whitespace_in_text_run_is_preserved(self):
        document_xml = '''
            <p>
              <r>
                <t>Foo</t>
              </r>
              <r>
                <rPr>
                    <b />
                </rPr>
                <t> </t>
              </r>
              <r>
                <t>Bar</t>
              </r>
            </p>
        '''
        document = WordprocessingDocumentFactory()
        document.add(MainDocumentPart, document_xml)

        expected_html = '<p>Foo Bar</p>'
        self.assert_document_generates_html(document, expected_html)
```