### PR TITLE
Heading inside complex field has strong applied

### DIFF
--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -180,6 +180,8 @@ class PyDocXExporter(object):
                     previous_parent_new_children.append(child)
             first_run.parent.children = previous_parent_new_children
 
+            field.parent = first_run.parent
+
             for run in field.children:
                 run.parent = field
 

--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -110,15 +110,23 @@ class PyDocXExporter(object):
             # document (e.g. fields)
             # In the first pass, discard any generated results
             self.first_pass = True
-            for result in self.export_node(document):
-                pass
+            self._first_pass_export()
 
-            self._convert_complex_fields_into_simple_fields()
+            self._post_first_pass_processing()
 
             # actually render the results
             self.first_pass = False
             for result in self.export_node(document):
                 yield result
+
+    def _first_pass_export(self):
+        document = self.main_document_part.document
+        if document:
+            for result in self.export_node(document):
+                pass
+
+    def _post_first_pass_processing(self):
+        self._convert_complex_fields_into_simple_fields()
 
     def _convert_complex_fields_into_simple_fields(self):
         if not self.complex_field_runs:

--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -140,6 +140,13 @@ class PyDocXExporter(object):
         runs_to_remove_by_field = {}
         runs_to_remove = set()
 
+        # All of the complex field runs need to be wrapped in simple fields,
+        # and then the runs need to be removed from their original container
+        # The new simple fields that contain the runs are inserted into the
+        # structure and the parent links are updated
+
+        # First create all the necessary simple fields and group the runs into
+        # their simple fields.
         for run in self.complex_field_runs:
             for child in run.children:
                 if field is not None and previous_run is not None:
@@ -174,6 +181,8 @@ class PyDocXExporter(object):
                     runs_to_remove.add(run)
             previous_run = run
 
+        # Next, remove all of the runs from the run's current parent, and
+        # inject the field in their place.
         for field in fields:
             runs_to_remove = runs_to_remove_by_field.get(field, set())
             if not field.children:
@@ -188,8 +197,12 @@ class PyDocXExporter(object):
                     previous_parent_new_children.append(child)
             first_run.parent.children = previous_parent_new_children
 
+            # If we don't do this, the field's parent will be None. That will
+            # break the hierarchy.
             field.parent = first_run.parent
 
+            # Update the run parent links to point to the field, since the
+            # field is now the run's new parent.
             for run in field.children:
                 run.parent = field
 

--- a/tests/export/html/test_field_code.py
+++ b/tests/export/html/test_field_code.py
@@ -7,9 +7,56 @@ from __future__ import (
 )
 
 
-from pydocx.openxml.packaging import MainDocumentPart
+from pydocx.openxml.packaging import MainDocumentPart, StyleDefinitionsPart
 from pydocx.test import DocumentGeneratorTestCase
 from pydocx.test.utils import WordprocessingDocumentFactory
+
+
+class HeadingTestCase(DocumentGeneratorTestCase):
+    def test_styles_are_ignored(self):
+        style_xml = '''
+            <style styleId="heading1" type="paragraph">
+              <name val="Heading 1"/>
+              <rPr>
+                <b val="on"/>
+                <caps val="on"/>
+                <smallCaps val="on"/>
+                <strike val="on"/>
+                <dstrike val="on"/>
+              </rPr>
+            </style>
+        '''
+
+        document_xml = '''
+            <p>
+                <pPr>
+                    <pStyle val="heading1"/>
+                </pPr>
+                <r>
+                    <fldChar fldCharType="begin"/>
+                </r>
+                <r>
+                    <instrText> FOOBAR baz</instrText>
+                </r>
+                <r>
+                    <fldChar fldCharType="separate"/>
+                </r>
+                <r>
+                    <t>AAA</t>
+                </r>
+                <r>
+                    <fldChar fldCharType="end"/>
+                </r>
+            </p>
+        '''
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <h1>AAA</h1>
+        '''
+        self.assert_document_generates_html(document, expected_html)
 
 
 class FieldCodeTestCase(DocumentGeneratorTestCase):

--- a/tests/export/html/test_field_code.py
+++ b/tests/export/html/test_field_code.py
@@ -139,7 +139,7 @@ class FieldCodeTestCase(DocumentGeneratorTestCase):
         self.assert_document_generates_html(document, expected_html)
 
 
-class HyperlinkFieldCodeTestCase(DocumentGeneratorTestCase):
+class HyperlinkTestCase(DocumentGeneratorTestCase):
     def test_spanning_single_paragraph(self):
         document_xml = '''
             <p>

--- a/tests/export/html/test_simple_field.py
+++ b/tests/export/html/test_simple_field.py
@@ -9,10 +9,47 @@ from __future__ import (
 from unittest import TestCase
 
 
-from pydocx.openxml.packaging import MainDocumentPart
+from pydocx.openxml.packaging import MainDocumentPart, StyleDefinitionsPart
 from pydocx.openxml.wordprocessing.simple_field import SimpleField
 from pydocx.test import DocumentGeneratorTestCase
 from pydocx.test.utils import WordprocessingDocumentFactory
+
+
+class HeadingTestCase(DocumentGeneratorTestCase):
+    def test_styles_are_ignored(self):
+        style_xml = '''
+            <style styleId="heading1" type="paragraph">
+              <name val="Heading 1"/>
+              <rPr>
+                <b val="on"/>
+                <caps val="on"/>
+                <smallCaps val="on"/>
+                <strike val="on"/>
+                <dstrike val="on"/>
+              </rPr>
+            </style>
+        '''
+
+        document_xml = '''
+            <p>
+                <pPr>
+                    <pStyle val="heading1"/>
+                </pPr>
+                <fldSimple instr="FOO bar">
+                    <r>
+                        <t>AAA</t>
+                    </r>
+                </fldSimple>
+            </p>
+        '''
+        document = WordprocessingDocumentFactory()
+        document.add(StyleDefinitionsPart, style_xml)
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <h1>AAA</h1>
+        '''
+        self.assert_document_generates_html(document, expected_html)
 
 
 class HyperlinkSimpleFieldTestCase(DocumentGeneratorTestCase):

--- a/tests/export/html/test_simple_field.py
+++ b/tests/export/html/test_simple_field.py
@@ -52,7 +52,7 @@ class HeadingTestCase(DocumentGeneratorTestCase):
         self.assert_document_generates_html(document, expected_html)
 
 
-class HyperlinkSimpleFieldTestCase(DocumentGeneratorTestCase):
+class HyperlinkTestCase(DocumentGeneratorTestCase):
     def test_single_run(self):
         document_xml = '''
             <p>


### PR DESCRIPTION
For example, the current output is:

```html
<h2><strong>Foo</strong></h2>
```

The desired output is

```html
<h2>Foo</h2>
```

This still works for non-complex field runs but is currently broken for complex field runs.