### PR TITLE
Include the anchor in a hyperlink target_uri if it exists

### DIFF
--- a/pydocx/openxml/wordprocessing/hyperlink.py
+++ b/pydocx/openxml/wordprocessing/hyperlink.py
@@ -15,6 +15,7 @@ class Hyperlink(XmlModel):
     XML_TAG = 'hyperlink'
 
     hyperlink_id = XmlAttribute(name='id')
+    anchor = XmlAttribute(name='anchor')
     children = XmlCollection(
         Run,
     )
@@ -32,7 +33,11 @@ class Hyperlink(XmlModel):
             )
         except KeyError:
             return None
-        return relationship.target_uri
+
+        if self.anchor:
+            return '{0}#{1}'.format(relationship.target_uri, self.anchor)
+        else:
+            return relationship.target_uri
 
     @property
     def target_uri(self):

--- a/tests/export/html/test_hyperlink.py
+++ b/tests/export/html/test_hyperlink.py
@@ -167,3 +167,30 @@ class HyperlinkTestCase(DocumentGeneratorTestCase):
 
         expected_html = '<p><a href="http://google.com">link</a>.</p>'
         self.assert_document_generates_html(document, expected_html)
+
+    def test_with_anchor(self):
+        document_xml = '''
+            <p>
+              <hyperlink anchor="testing" id="foobar">
+                <r>
+                  <t>link</t>
+                </r>
+              </hyperlink>
+              <r>
+                <t>.</t>
+              </r>
+            </p>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document_rels = document.relationship_format.format(
+            id='foobar',
+            type='foo/hyperlink',
+            target='http://google.com',
+            target_mode='External',
+        )
+
+        document.add(MainDocumentPart, document_xml, document_rels)
+
+        expected_html = '<p><a href="http://google.com#testing">link</a>.</p>'
+        self.assert_document_generates_html(document, expected_html)


### PR DESCRIPTION
Some representations of Hyperlinks separate the link from the anchor. The resulting href values in the HTML don't include the anchor part.

This pull-request fixes that. More details in issue #205.

Closes #205