### PR TITLE
Fix #197: Conversion using CLI

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Sam Protnow <samson91787@gmail.com>
 Jason Ward <jason.louard.ward@gmail.com>
 Kyle Gibson <kyle.gibson@frozenonline.com>
 Chirica Gheorghe <https://github.com/botzill>
+Anirudha Bose <ani07nov@gmail.com>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.9.6**
+
+- Fixed issue in PyDocX CLI tool and added new test cases for the same
+
 **0.9.5**
 
 - Simple and Complex field hyperlinks now support bookmarks / internal anchors

--- a/pydocx/__init__.py
+++ b/pydocx/__init__.py
@@ -6,4 +6,4 @@ __all__ = [
     'PyDocX',
 ]
 
-__version__ = '0.9.5'
+__version__ = '0.9.6'

--- a/pydocx/__main__.py
+++ b/pydocx/__main__.py
@@ -43,9 +43,11 @@ def main(args=None):
 
     return convert(output_type, docx_path, output_path)
 
+
 def cli():
     # Entry point for PyDocX CLI tool
     sys.exit(main(args=sys.argv[1:]) or 0)
+
 
 if __name__ == "__main__":
     sys.exit(main(args=sys.argv[1:]) or 0)

--- a/pydocx/__main__.py
+++ b/pydocx/__main__.py
@@ -43,5 +43,9 @@ def main(args=None):
 
     return convert(output_type, docx_path, output_path)
 
+def cli():
+    # Entry point for PyDocX CLI tool
+    sys.exit(main(args=sys.argv[1:]) or 0)
+
 if __name__ == "__main__":
     sys.exit(main(args=sys.argv[1:]) or 0)

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def main():
         long_description=read('README.rst'),
         entry_points={
             'console_scripts': [
-                'pydocx = pydocx.__main__:main',
+                'pydocx = pydocx.__main__:cli',
             ],
         },
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,15 +5,16 @@ from __future__ import (
 )
 
 from os import unlink
+from shutil import copyfile
+from subprocess import Popen, PIPE
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
-from shutil import copyfile
 
 from nose import SkipTest
 
+from pydocx.__main__ import main
 from pydocx.test.testcases import BASE_HTML
 from pydocx.test.utils import assert_html_equal
-from pydocx.__main__ import main
 
 
 class MainTestCase(TestCase):
@@ -70,3 +71,30 @@ class MainTestCase(TestCase):
             self.assertEqual(result, 0)
             unlink(input_docx.name)
             input_docx.close()
+
+    def test_cli_return_code_with_no_args(self):
+        result = Popen(['pydocx'], stdout=PIPE).wait()
+        self.assertEqual(result, 1)
+
+    def test_cli_return_code_with_one_args(self):
+        result = Popen(['pydocx', 'foo'], stdout=PIPE).wait()
+        self.assertEqual(result, 1)
+
+    def test_cli_return_code_with_two_args(self):
+        result = Popen(['pydocx', 'foo', 'bar'], stdout=PIPE).wait()
+        self.assertEqual(result, 1)
+
+    def test_cli_return_code_with_three_args(self):
+        result = Popen(['pydocx', 'foo', 'bar', 'baz'], stdout=PIPE).wait()
+        self.assertEqual(result, 2)
+
+    def test_cli_convert_to_html_status_code(self):
+        with NamedTemporaryFile() as f:
+            result = Popen([
+                'pydocx',
+                '--html',
+                'tests/fixtures/inline_tags.docx',
+                f.name
+            ],
+            stdout=PIPE).wait()
+        self.assertEqual(result, 0)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -95,6 +95,5 @@ class MainTestCase(TestCase):
                 '--html',
                 'tests/fixtures/inline_tags.docx',
                 f.name
-            ],
-            stdout=PIPE).wait()
+            ], stdout=PIPE).wait()
         self.assertEqual(result, 0)


### PR DESCRIPTION
- Adds a new entry-point function for the command line tool `pydocx` in order to avoid ambiguity between invocation through CLI and invocation during tests
- Implement new tests for the CLI tool