### PR TITLE
Add a plugins section to the documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,4 +11,5 @@ PyDocX
    export_mixins
    enumerated_list_detection
    development
+   plugins
    release_notes

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -1,0 +1,36 @@
+#######
+Plugins
+#######
+
+You may find yourself needing
+a feature in PyDocX that doesn't exist
+in the core library.
+
+If it's something that should exist, the
+PyDocX project is always open to new
+contributions. Details of how to contibute
+can be found in :doc:`/development`.
+
+For things that don't fit in the core
+library, it's easy to build a plugin
+based on the :doc:`Extending PyDocX </extending>` and
+:doc:`Export Mixins </export_mixins>` sections.
+
+If you do build a plugin, edit this
+documentation and add it below so that
+other developers can find it.
+
+-----------------
+Available Plugins
+-----------------
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Plugin
+     - Description
+   * - `pydocx-resize-images <https://github.com/jhubert/pydocx-resize-images>`_
+     - Resizes large images to the dimensions they are in the docx file
+   * - `pydocx-s3-images <https://github.com/jhubert/pydocx-s3-images>`_
+     - Uploads images to S3 instead of returning Data URIs


### PR DESCRIPTION
This is a quick pass at some documentation for the third party plugins I wrote. I tried using the language that the rest of the documentation uses, but I may have injected a bit more personality than intended. Very open to rewrites; Just wanted to get something going.

Per #195  /cc @winhamwr 

The resulting documentation page looks like this:

![image](https://cloud.githubusercontent.com/assets/3384/15238900/7772943a-1892-11e6-89aa-5b155f36e13e.png)
