### PR TITLE
Picts can have rects, which can have textbox

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.9.8**
+
+- Pict elements can now contain Rect elements.
+
 **0.9.7**
 
 - Text colors other than black and white are no longer ignored

--- a/pydocx/__init__.py
+++ b/pydocx/__init__.py
@@ -6,4 +6,4 @@ __all__ = [
     'PyDocX',
 ]
 
-__version__ = '0.9.7'
+__version__ = '0.9.8'

--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -63,6 +63,7 @@ class PyDocXExporter(object):
             wordprocessing.FieldCode: self.export_field_code,
             wordprocessing.SimpleField: self.export_simple_field,
             vml.Shape: self.export_vml_shape,
+            vml.Rect: self.export_vml_rect,
             vml.ImageData: self.export_vml_image_data,
             vml.Textbox: self.export_textbox,
             wordprocessing.EmbeddedObject: self.export_embedded_object,
@@ -480,6 +481,9 @@ class PyDocXExporter(object):
 
     def export_vml_shape(self, shape):
         return self.yield_nested(shape.children, self.export_node)
+
+    def export_vml_rect(self, rect):
+        return self.yield_nested(rect.children, self.export_node)
 
     def export_embedded_object(self, obj):
         return self.yield_nested(obj.children, self.export_node)

--- a/pydocx/openxml/vml/__init__.py
+++ b/pydocx/openxml/vml/__init__.py
@@ -1,10 +1,12 @@
 # coding: utf-8
 from pydocx.openxml.vml.image_data import ImageData
+from pydocx.openxml.vml.rect import Rect
 from pydocx.openxml.vml.shape import Shape
 from pydocx.openxml.vml.textbox import Textbox
 
 __all__ = [
     'ImageData',
+    'Rect',
     'Shape',
     'Textbox',
 ]

--- a/pydocx/openxml/vml/rect.py
+++ b/pydocx/openxml/vml/rect.py
@@ -6,10 +6,10 @@ from __future__ import (
 )
 
 from pydocx.models import XmlModel, XmlCollection
-from pydocx.openxml.vml import Shape, Rect
+from pydocx.openxml.vml.image_data import ImageData
 
 
-class Picture(XmlModel):
-    XML_TAG = 'pict'
+class Rect(XmlModel):
+    XML_TAG = 'rect'
 
-    children = XmlCollection(Shape, Rect)
+    children = XmlCollection(ImageData, 'vml.Textbox')

--- a/tests/export/html/test_rect.py
+++ b/tests/export/html/test_rect.py
@@ -1,0 +1,46 @@
+# coding: utf-8
+
+from __future__ import (
+    absolute_import,
+    print_function,
+    unicode_literals,
+)
+
+from pydocx.test import DocumentGeneratorTestCase
+from pydocx.test.utils import WordprocessingDocumentFactory
+from pydocx.openxml.packaging import MainDocumentPart
+
+
+class RectTestCase(DocumentGeneratorTestCase):
+    def test_rect_with_textbox(self):
+        document_xml = '''
+            <p>
+                <r>
+                    <pict>
+                        <rect>
+                            <textbox>
+                                <txbxContent>
+                                    <p>
+                                        <r>
+                                            <t>AAA</t>
+                                        </r>
+                                    </p>
+                                </txbxContent>
+                            </textbox>
+                        </rect>
+                    </pict>
+                </r>
+            </p>
+        '''
+
+        document = WordprocessingDocumentFactory()
+        document.add(MainDocumentPart, document_xml)
+
+        expected_html = '''
+            <p>
+                <p>
+                    AAA
+                </p>
+            </p>
+        '''
+        self.assert_document_generates_html(document, expected_html)


### PR DESCRIPTION
```
<mc:AlternateContent>
  <mc:Fallback>
    <w:pict>
      <v:rect fillcolor="#FFFFFF" strokecolor="#000000" strokeweight="1pt" style="position:absolute;rotation:0">
        <v:textbox>
          <w:txbxContent>
            <w:p>
              <w:r>
                <w:t>AAA</w:t>
              </w:r>
            </w:p>
          <w:txbxContent>
        <v:textbox>
      <v:rect>
    <w:pict>
  <mc:Fallback>
</mc:AlternateContent>

```