### PR TITLE
Rect tag needs `get_style` method.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.9.9**
+
+- Rect elements now correctly handle image data
+
 **0.9.8**
 
 - Textboxes can now contain tables.

--- a/pydocx/__init__.py
+++ b/pydocx/__init__.py
@@ -6,4 +6,4 @@ __all__ = [
     'PyDocX',
 ]
 
-__version__ = '0.9.8'
+__version__ = '0.9.9'

--- a/pydocx/openxml/vml/rect.py
+++ b/pydocx/openxml/vml/rect.py
@@ -5,11 +5,22 @@ from __future__ import (
     unicode_literals,
 )
 
-from pydocx.models import XmlModel, XmlCollection
+from pydocx.models import XmlModel, XmlCollection, XmlAttribute
 from pydocx.openxml.vml.image_data import ImageData
 
 
 class Rect(XmlModel):
     XML_TAG = 'rect'
 
+    style = XmlAttribute()
     children = XmlCollection(ImageData, 'vml.Textbox')
+
+    # TODO perhaps we could have a prepare_style, or clean_style convention?
+    def get_style(self):
+        if self.style:
+            return dict(
+                item.split(':', 1)
+                for item in self.style.split(';')
+                if item
+            )
+        return {}

--- a/pydocx/openxml/vml/shape.py
+++ b/pydocx/openxml/vml/shape.py
@@ -14,8 +14,8 @@ class Shape(XmlModel):
 
     style = XmlAttribute()
     children = XmlCollection(ImageData, 'vml.Textbox')
-    # TODO perhaps we could have a prepare_style, or clean_style convention?
 
+    # TODO perhaps we could have a prepare_style, or clean_style convention?
     def get_style(self):
         if self.style:
             return dict(

--- a/pydocx/test/document_builder.py
+++ b/pydocx/test/document_builder.py
@@ -19,6 +19,7 @@ templates = {
     'p': 'p.xml',
     'pict': 'pict.xml',
     'r': 'r.xml',
+    'rect': 'rect.xml',
     'rpr': 'rpr.xml',
     'sdt': 'sdt.xml',
     'sectPr': 'sectPr.xml',
@@ -247,6 +248,16 @@ class DocxBuilder(object):
     @classmethod
     def pict(self, r_id=None, height=None, width=None):
         template = env.get_template(templates['pict'])
+        return template_render(
+            template,
+            r_id=r_id,
+            height=height,
+            width=width,
+        )
+
+    @classmethod
+    def rect(self, r_id=None, height=None, width=None):
+        template = env.get_template(templates['rect'])
         return template_render(
             template,
             r_id=r_id,

--- a/tests/export/test_xml.py
+++ b/tests/export/test_xml.py
@@ -30,19 +30,29 @@ class ImageLocal(TranslationTestCase):
             target_path='media/image2.jpeg',
             data=b'content2',
         ),
+        dict(
+            relationship_id='rId2',
+            relationship_type=ImagePart.relationship_type,
+            external=False,
+            target_path='media/image3.jpeg',
+            data=b'content3',
+        ),
     ]
 
     expected_output = '''
     <p><img src="data:image/jpeg;base64,Y29udGVudDE=" /></p>
     <p><img src="data:image/jpeg;base64,Y29udGVudDI=" /></p>
+    <p><img src="data:image/jpeg;base64,Y29udGVudDM=" /></p>
     '''
 
     def get_xml(self):
         drawing = DXB.drawing(height=None, width=None, r_id='rId0')
         pict = DXB.pict(height=None, width=None, r_id='rId1')
+        rect = DXB.rect(height=None, width=None, r_id='rId2')
         tags = [
             drawing,
             pict,
+            rect,
         ]
         body = b''
         for el in tags:
@@ -67,6 +77,13 @@ class ImageTestCase(TranslationTestCase):
             target_path='media/image2.jpeg',
             data=b'content2',
         ),
+        dict(
+            relationship_id='rId2',
+            relationship_type=ImagePart.relationship_type,
+            external=False,
+            target_path='media/image3.jpeg',
+            data=b'content3',
+        ),
     ]
 
     expected_output = '''
@@ -84,14 +101,23 @@ class ImageTestCase(TranslationTestCase):
                 width="41pt"
             />
         </p>
+        <p>
+            <img
+                height="22pt"
+                src="data:image/jpeg;base64,Y29udGVudDM="
+                width="42pt"
+            />
+        </p>
     '''
 
     def get_xml(self):
         drawing = DXB.drawing(height=20, width=40, r_id='rId0')
         pict = DXB.pict(height=21, width=41, r_id='rId1')
+        rect = DXB.rect(height=22, width=42, r_id='rId2')
         tags = [
             drawing,
             pict,
+            rect,
         ]
         body = b''
         for el in tags:

--- a/tests/templates/rect.xml
+++ b/tests/templates/rect.xml
@@ -1,0 +1,18 @@
+<w:p w:rsidR="00E94BDC" w:rsidRPr="003638EA" w:rsidRDefault="00E94BDC" w:rsidP="00E94BDC">
+    <w:pPr>
+        <w:rPr>
+            <w:color w:val="000000"/>
+        </w:rPr>
+    </w:pPr>
+    <w:r w:rsidR="00360165">
+        <w:rPr>
+            <w:color w:val="000000"/>
+        </w:rPr>
+        <w:pict>
+            <v:rect {%if width or height %}style="{% if width %}width:{{ width }}pt;{%endif%}{% if height %}height:{{ height }}pt{%endif%}"{% endif %}>
+
+				{% if r_id %}<v:imagedata r:id="{{ r_id }}" o:title="New Picture"/>{% endif %}
+			</v:rect>
+		</w:pict>
+	</w:r>
+</w:p>


### PR DESCRIPTION
```
 File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 218, in export_node
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/html.py", line 127, in apply
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 252, in yield_nested
    for result in func(item):
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 218, in export_node
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/html.py", line 591, in export_table_cell
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/html.py", line 127, in apply
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 267, in yield_nested_with_line_breaks_between_paragraphs
    for result in func(item):
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 218, in export_node
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/html.py", line 278, in export_paragraph
    results = is_not_empty_and_not_only_whitespace(results)
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/html.py", line 78, in is_not_empty_and_not_only_whitespace
    for item in gen:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 252, in yield_nested
    for result in func(item):
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 218, in export_node
    for result in results:
  File "/opt/pstat/versions/20160523-170546/pstat/core/import_translation/translation.py", line 251, in export_run
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 252, in yield_nested
    for result in func(item):
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 218, in export_node
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 252, in yield_nested
    for result in func(item):
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 218, in export_node
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 252, in yield_nested
    for result in func(item):
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 218, in export_node
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/html.py", line 666, in export_vml_image_data
    width, height = image_data.get_picture_extents()
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/openxml/vml/image_data.py", line 21, in get_picture_extents
    style = self.parent.get_style()
AttributeError: 'Rect' object has no attribute 'get_style'
```