### PR TITLE
`ValueError: invalid literal for int() with base 10:` crash calling `start_margin_position`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**0.9.10**
+
+- Correctly handle margin positions with decimal points.
+
 **0.9.9**
 
 - Rect elements now correctly handle image data

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 **0.9.10**
 
-- Correctly handle margin positions with decimal points.
+- No longer error when processing margin positions with decimal points.
 
 **0.9.9**
 

--- a/pydocx/openxml/wordprocessing/paragraph_properties.py
+++ b/pydocx/openxml/wordprocessing/paragraph_properties.py
@@ -35,11 +35,11 @@ class ParagraphProperties(XmlModel):
         # ignored.
         start_margin = 0
         if self.indentation_left:
-            start_margin += int(self.indentation_left)
+            start_margin += int(float(self.indentation_left))
         if self.indentation_hanging:
-            start_margin -= int(self.indentation_hanging)
+            start_margin -= int(float(self.indentation_hanging))
         elif self.indentation_first_line:
-            start_margin += int(self.indentation_first_line)
+            start_margin += int(float(self.indentation_first_line))
         if start_margin:
             return start_margin
         return 0

--- a/tests/openxml/wordprocessing/test_paragraph_properties.py
+++ b/tests/openxml/wordprocessing/test_paragraph_properties.py
@@ -105,3 +105,21 @@ class StartMarginPositionTestCase(ParagraphPropertiesTestBase):
         '''
         properties = self._load_from_xml(xml)
         self.assertEqual(properties.start_margin_position, 100)
+
+    def test_allow_decimal_indentation_for_hanging(self):
+        xml = '''
+            <pPr>
+                <ind left="123.0" hanging="23.0" />
+            </pPr>
+        '''
+        properties = self._load_from_xml(xml)
+        self.assertEqual(properties.start_margin_position, 100)
+
+    def test_allow_decimal_indentation_for_first_line(self):
+        xml = '''
+            <pPr>
+                <ind left="123.0" firstLine="50.0" />
+            </pPr>
+        '''
+        properties = self._load_from_xml(xml)
+        self.assertEqual(properties.start_margin_position, 173)

--- a/tests/openxml/wordprocessing/test_paragraph_properties.py
+++ b/tests/openxml/wordprocessing/test_paragraph_properties.py
@@ -109,7 +109,7 @@ class StartMarginPositionTestCase(ParagraphPropertiesTestBase):
     def test_allow_decimal_indentation_for_hanging(self):
         xml = '''
             <pPr>
-                <ind left="123.0" hanging="23.0" />
+                <ind left="123.1" hanging="23.2" />
             </pPr>
         '''
         properties = self._load_from_xml(xml)
@@ -118,7 +118,7 @@ class StartMarginPositionTestCase(ParagraphPropertiesTestBase):
     def test_allow_decimal_indentation_for_first_line(self):
         xml = '''
             <pPr>
-                <ind left="123.0" firstLine="50.0" />
+                <ind left="123.3" firstLine="50.4" />
             </pPr>
         '''
         properties = self._load_from_xml(xml)


### PR DESCRIPTION
Some .docx files that we're seeing in the wild are using a non-integer value for the `indentation_hanging` attribute. It looks something like: `<ind hanging="504.00000000000006">`

This causes a crash when we try to [cast to int](https://github.com/CenterForOpenScience/pydocx/blob/master/pydocx/openxml/wordprocessing/paragraph_properties.py#L40).

I'm not sure if these documents are violating the spec, but we've seen 123 cases of this in the last 8 days.

### Traceback

```python
Traceback (most recent call last):
  File "/home/policystat/env/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/policystat/env/lib/python2.7/site-packages/newrelic-2.58.1.44/newrelic/hooks/application_celery.py", line 66, in wrapper
    return wrapped(*args, **kwargs)
  File "/home/policystat/env/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/policystat/env/lib/python2.7/site-packages/jobtastic/task.py", line 362, in run
    task_result = self.calculate_result(*args, **kwargs)
  File "/opt/pstat/versions/20160726-154201/pstat/core/import_translation/tasks/__init__.py", line 151, in calculate_result
    self.error_handler(e, *args, **kwargs)
  File "/opt/pstat/versions/20160726-154201/pstat/core/implementation/tasks.py", line 66, in error_handler
    super(BuildImport, self).error_handler(e, *args, **kwargs)
  File "/opt/pstat/versions/20160726-154201/pstat/core/import_translation/tasks/__init__.py", line 133, in calculate_result
    result_dict = self.extract_html(*args, **kwargs)
  File "/opt/pstat/versions/20160726-154201/pstat/core/implementation/tasks.py", line 59, in extract_html
    force_nodupe=True,
  File "/opt/pstat/versions/20160726-154201/pstat/document_import/models.py", line 1773, in build_import
    document_import = self._build_import(category, user, force_nodupe, tenant)
  File "/opt/pstat/versions/20160726-154201/pstat/document_import/models.py", line 1684, in _build_import
    metadata=metadata,
  File "/opt/pstat/versions/20160726-154201/pstat/core/import_translation/translation.py", line 711, in get_html_from_file
    html = exporter.export()
  File "/opt/pstat/versions/20160726-154201/pstat/core/import_translation/translation.py", line 151, in export
    html = super(DocxToHTMLExporter, self).export()
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/html.py", line 211, in export
    for result in super(PyDocXHTMLExporter, self).export()
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/html.py", line 209, in <genexpr>
    result.to_html() if isinstance(result, HtmlTag)
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 123, in export
    for result in self.export_node(document):
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 218, in export_node
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/html.py", line 127, in apply
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 218, in export_node
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/html.py", line 127, in apply
    for result in results:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 251, in yield_nested
    for item in iterable:
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/base.py", line 290, in yield_numbering_spans
    numbering_spans = builder.get_numbering_spans()
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/numbering_span.py", line 415, in get_numbering_spans
    new_items.extend(self.process_component(index, component))
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/numbering_span.py", line 399, in process_component
    for new_component in self.handle_paragraph(index, component):
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/numbering_span.py", line 362, in handle_paragraph
    level = self.get_numbering_level(paragraph)
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/util/memoize.py", line 31, in __call__
    value = self.func(*args)
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/numbering_span.py", line 476, in get_numbering_level
    return self.detect_faked_list(paragraph)
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/numbering_span.py", line 563, in detect_faked_list
    left_position = self.get_left_position_for_paragraph(paragraph)
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/util/memoize.py", line 31, in __call__
    value = self.func(*args)
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/export/numbering_span.py", line 516, in get_left_position_for_paragraph
    left_position = properties.start_margin_position
  File "/home/policystat/env/lib/python2.7/site-packages/pydocx/openxml/wordprocessing/paragraph_properties.py", line 40, in start_margin_position
    start_margin -= int(self.indentation_hanging)
ValueError: invalid literal for int() with base 10: '504.00000000000006'
```