### PR TITLE
Render empty paragraph tags

### DIFF
--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -341,8 +341,10 @@ class PyDocXExporter(object):
 
         # TODO squash multiple sequential text nodes into one?
         results = self.yield_nested(run.children, self.export_node)
+
         if run.effective_properties:
             results = self.export_run_apply_properties(run, results)
+
         return results
 
     def get_run_styles_to_apply(self, run):

--- a/pydocx/openxml/wordprocessing/paragraph.py
+++ b/pydocx/openxml/wordprocessing/paragraph.py
@@ -6,17 +6,17 @@ from __future__ import (
 )
 
 from pydocx.models import XmlModel, XmlCollection, XmlChild
+from pydocx.openxml.wordprocessing.bookmark import Bookmark
+from pydocx.openxml.wordprocessing.deleted_run import DeletedRun
 from pydocx.openxml.wordprocessing.hyperlink import Hyperlink
+from pydocx.openxml.wordprocessing.inserted_run import InsertedRun
 from pydocx.openxml.wordprocessing.paragraph_properties import ParagraphProperties  # noqa
 from pydocx.openxml.wordprocessing.run import Run
-from pydocx.openxml.wordprocessing.tab_char import TabChar
-from pydocx.openxml.wordprocessing.text import Text
-from pydocx.openxml.wordprocessing.smart_tag_run import SmartTagRun
-from pydocx.openxml.wordprocessing.inserted_run import InsertedRun
-from pydocx.openxml.wordprocessing.deleted_run import DeletedRun
 from pydocx.openxml.wordprocessing.sdt_run import SdtRun
 from pydocx.openxml.wordprocessing.simple_field import SimpleField
-from pydocx.openxml.wordprocessing.bookmark import Bookmark
+from pydocx.openxml.wordprocessing.smart_tag_run import SmartTagRun
+from pydocx.openxml.wordprocessing.tab_char import TabChar
+from pydocx.openxml.wordprocessing.text import Text
 
 
 class Paragraph(XmlModel):
@@ -38,6 +38,20 @@ class Paragraph(XmlModel):
     def __init__(self, **kwargs):
         super(Paragraph, self).__init__(**kwargs)
         self._effective_properties = None
+
+    @property
+    def is_empty(self):
+        if not self.children:
+            return True
+
+        # we may have cases when a paragraph has a Bookmark with name '_GoBack'
+        # and we should treat it as empty paragraph
+        if len(self.children) == 1 and \
+                isinstance(self.children[0], Bookmark) and \
+                self.children[0].name in ('_GoBack',):
+            return True
+
+        return False
 
     @property
     def effective_properties(self):

--- a/pydocx/test/testcases.py
+++ b/pydocx/test/testcases.py
@@ -50,6 +50,7 @@ STYLE = (
     '.pydocx-tab {display:inline-block;width:4em}'
     '.pydocx-underline {text-decoration:underline}'
     'body {margin:0px auto;width:51.00em}'
+    'p {margin:0}'
     '</style>'
 )
 


### PR DESCRIPTION
Here is a version simple version of rendering empty paragraph. Even more this will render all texts inside `<p>` this way we should not care about adding custom break line. 

Example: 

input(.docx):
<img width="237" alt="screen shot 2017-02-13 at 2 39 34 pm" src="https://cloud.githubusercontent.com/assets/4686040/22883750/5183e2c8-f1fa-11e6-9ec5-ed3f9bd72b04.png">

output html:
<img width="192" alt="screen shot 2017-02-13 at 2 40 26 pm" src="https://cloud.githubusercontent.com/assets/4686040/22883763/65239576-f1fa-11e6-8c4b-a72065ed3d58.png">

output html source:

```html
<ol class="pydocx-list-style-type-decimal">
    <li><p>AAA <span style="color:#FF0000">RRR</span></p>
        <p><span class="pydocx-underline"><em>Italic</em></span><span class="pydocx-underline"><em>U</em></span></p>
        <p>&nbsp;</p>
        <p>&nbsp;</p></li>
    <li><p>BBB</p>
        <p>&nbsp;</p>
        <p>&nbsp;</p></li>
    <li><p>CCC</p></li>
</ol>
```
Note: tests not yet adapted. 

Let me know if you have any feedback on this. 