### PR TITLE
Fixed - prevents underline from being stripped on whitespaces.

### DIFF
--- a/pydocx/export/html.py
+++ b/pydocx/export/html.py
@@ -497,7 +497,17 @@ class PyDocXHTMLExporter(PyDocXExporter):
             'class': 'pydocx-underline',
         }
         tag = HtmlTag('span', **attrs)
-        return self.export_run_property(tag, run, results)
+
+        # Added function to apply underline to whitespace.
+        def preserve_spaces(items):
+            for item in items:
+                # If the item is only whitespace, convert it to a space entity
+                if is_only_whitespace(item) and hasattr(item, 'replace'):
+                    yield item.replace(' ', '&#160;')
+                else:
+                    yield item
+
+        return self.export_run_property(tag, run, preserve_spaces(results))
 
     def export_run_property_caps(self, run, results):
         attrs = {


### PR DESCRIPTION
Issue # 258 was for underline not being applied to white spaces between text. I went in and added a function to maintain that within an underlined related conversion method.