### PR TITLE
Fix: skip hidded table rows during HTML export

### DIFF
--- a/pydocx/export/base.py
+++ b/pydocx/export/base.py
@@ -427,6 +427,8 @@ class PyDocXExporter(object):
         return self.yield_nested(table.rows, self.export_node)
 
     def export_table_row(self, table_row):
+        if table_row.is_hidden:
+            return  # skip — row is marked hidden in the docx
         return self.yield_nested(table_row.cells, self.export_node)
 
     def export_table_cell(self, table_cell):

--- a/pydocx/openxml/wordprocessing/__init__.py
+++ b/pydocx/openxml/wordprocessing/__init__.py
@@ -44,6 +44,7 @@ from pydocx.openxml.wordprocessing.table_cell_properties import TableCellPropert
 from pydocx.openxml.wordprocessing.table_row import TableRow
 from pydocx.openxml.wordprocessing.text import Text
 from pydocx.openxml.wordprocessing.textbox_content import TxBxContent
+from pydocx.openxml.wordprocessing.table_row_properties import TableRowProperties  # noqa
 
 __all__ = [
     'AbstractNum',

--- a/pydocx/openxml/wordprocessing/table_row.py
+++ b/pydocx/openxml/wordprocessing/table_row.py
@@ -5,13 +5,20 @@ from __future__ import (
     unicode_literals,
 )
 
-from pydocx.models import XmlModel, XmlCollection
+from pydocx.models import XmlModel, XmlChild, XmlCollection
 from pydocx.openxml.wordprocessing.table_cell import TableCell
+from pydocx.openxml.wordprocessing.table_row_properties import TableRowProperties  # NEW
 
 
 class TableRow(XmlModel):
     XML_TAG = 'tr'
 
-    cells = XmlCollection(
-        TableCell,
-    )
+    # NEW: wire in the trPr properties element
+    properties = XmlChild(type=TableRowProperties)
+
+    cells = XmlCollection(TableCell)
+
+    @property
+    def is_hidden(self):
+        """Return True if this row has <w:trPr><w:hidden/></w:trPr>."""
+        return self.properties is not None and self.properties.hidden is not None

--- a/pydocx/openxml/wordprocessing/table_row_properties.py
+++ b/pydocx/openxml/wordprocessing/table_row_properties.py
@@ -1,0 +1,17 @@
+# coding: utf-8
+from __future__ import (
+    absolute_import,
+    print_function,
+    unicode_literals,
+)
+
+from pydocx.models import XmlModel, XmlChild
+
+
+class TableRowProperties(XmlModel):
+    XML_TAG = 'trPr'
+
+    # The presence of <w:hidden/> means the row is hidden.
+    # XmlChild without attrname returns the raw element if found,
+    # or None (default) if absent — so bool(hidden) works directly.
+    hidden = XmlChild(name='hidden')


### PR DESCRIPTION
Fix: skip hidden table rows during HTML export (fixes #262)

Add TableRowProperties model to detect <w:trPr><w:hidden/> and
skip hidden rows in export_table_row().

closes #262 